### PR TITLE
Add line endings config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=crlf

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
 	"trailingComma": "es5",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
-	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }],
+	"endOfLine": "crlf"
 }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Thanks for everything! See you next game.
 
 ## Requirements
 
-- Node 19+
-- Python 3.9+ (optional - for refreshing the data store)
+-   Node 19+
+-   Python 3.9+ (optional - for refreshing the data store)
 
 ## Developing
 


### PR DESCRIPTION
I forgot about line endings when adding Prettier.

Prettier defaults to linux/mac style `lf` line endings, which I usually prefer, but since the repo currently has `crlf` on all files, right now if you run `format` it changes the line endings of every formatted file. I defaulted to the path of least resistance and added `crlf` to the Prettier config as well as `.gitattributes` so git doesn't mess with it either.

If we want to just bite the bullet and go with `lf` instead, I'll change the configs and add the format commit that will set the line endings of every file. I request your reviews.