### PR TITLE
Add video list pagination to show page

### DIFF
--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -13,7 +13,6 @@
 
 <script lang="ts">
 	import { goto } from '$app/navigation'
-	import { page } from '$app/stores'
 
 	export let current: number = 1
 	export let results: number
@@ -47,7 +46,7 @@
 		<li>
 			<a
 				on:click|preventDefault={() => goto(`?page=${current - 1}`)}
-				href="{$page.url.pathname}?page={current - 1}"
+				href="?page={current - 1}"
 				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
 					<path d="M7 5H1l3 -3M1 5l3 3" />
 				</svg></a
@@ -57,9 +56,8 @@
 	{#each buttons as button}
 		{#if button}
 			<li class:current={button === current}>
-				<a
-					on:click|preventDefault={() => goto(`?page=${button}`)}
-					href="{$page.url.pathname}?page={button}">{button}</a
+				<a on:click|preventDefault={() => goto(`?page=${button}`)} href="?page={button}"
+					>{button}</a
 				>
 			</li>
 		{:else}
@@ -70,7 +68,7 @@
 		<li>
 			<a
 				on:click|preventDefault={() => goto(`?page=${current + 1}`)}
-				href="{$page.url.pathname}?page={current + 1}"
+				href="?page={current + 1}"
 				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
 					<path d="M1 5H7l-3 -3M7 5l-3 3" />
 				</svg></a

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,10 +1,20 @@
 <script context="module" lang="ts">
-	export const PAGE_SIZE = 50
+	const PAGE_SIZE = 50
+
+	export function paginate<T extends any[]>(pageParam: string | null, items: T) {
+		const number = pageParam ? parseInt(pageParam) : 1
+		const itemIndexStart = (number - 1) * PAGE_SIZE
+		return {
+			number,
+			items: items.slice(itemIndexStart, itemIndexStart + PAGE_SIZE) as T,
+		}
+	}
 </script>
 
 <script lang="ts">
 	import { goto } from '$app/navigation'
 	import { page } from '$app/stores'
+
 	export let current: number = 1
 	export let results: number
 
@@ -13,6 +23,7 @@
 
 	function createPageButtons(current: number, total: number) {
 		const buttons: (number | null)[] = []
+		if (total === 1) return buttons
 		const startPage = Math.max(1, Math.min(total - 4, current - 2))
 		const endPage = Math.min(total, startPage + 4)
 		for (let p = startPage; p <= endPage; p++) {

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -14,11 +14,11 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
 
-	export let current: number = 1
-	export let results: number
+	export let currentPage: number = 1
+	export let totalResults: number
 
-	$: totalPages = Math.ceil(results / PAGE_SIZE)
-	$: buttons = createPageButtons(current, totalPages)
+	$: totalPages = Math.ceil(totalResults / PAGE_SIZE)
+	$: buttons = createPageButtons(currentPage, totalPages)
 
 	function createPageButtons(current: number, total: number) {
 		const buttons: (number | null)[] = []
@@ -41,12 +41,12 @@
 </script>
 
 <ul>
-	<li>{results} results</li>
-	{#if current > 1}
+	<li>{totalResults} results</li>
+	{#if currentPage > 1}
 		<li>
 			<a
-				on:click|preventDefault={() => goto(`?page=${current - 1}`)}
-				href="?page={current - 1}"
+				on:click|preventDefault={() => goto(`?page=${currentPage - 1}`)}
+				href="?page={currentPage - 1}"
 				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
 					<path d="M7 5H1l3 -3M1 5l3 3" />
 				</svg></a
@@ -55,7 +55,7 @@
 	{/if}
 	{#each buttons as button}
 		{#if button}
-			<li class:current={button === current}>
+			<li class:current={button === currentPage}>
 				<a on:click|preventDefault={() => goto(`?page=${button}`)} href="?page={button}"
 					>{button}</a
 				>
@@ -64,11 +64,11 @@
 			<li class="ellipse">...</li>
 		{/if}
 	{/each}
-	{#if current < totalPages}
+	{#if currentPage < totalPages}
 		<li>
 			<a
-				on:click|preventDefault={() => goto(`?page=${current + 1}`)}
-				href="?page={current + 1}"
+				on:click|preventDefault={() => goto(`?page=${currentPage + 1}`)}
+				href="?page={currentPage + 1}"
 				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
 					<path d="M1 5H7l-3 -3M7 5l-3 3" />
 				</svg></a

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -8,8 +8,6 @@
 </script>
 
 <script lang="ts">
-	import { goto } from '$app/navigation'
-
 	export let currentPage: number = 1
 	export let totalResults: number
 
@@ -40,9 +38,7 @@
 	<li>{totalResults} results</li>
 	{#if currentPage > 1}
 		<li>
-			<a
-				on:click|preventDefault={() => goto(`?page=${currentPage - 1}`)}
-				href="?page={currentPage - 1}"
+			<a href="?page={currentPage - 1}"
 				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
 					<path d="M7 5H1l3 -3M1 5l3 3" />
 				</svg></a
@@ -52,9 +48,7 @@
 	{#each buttons as button}
 		{#if button}
 			<li class:current={button === currentPage}>
-				<a on:click|preventDefault={() => goto(`?page=${button}`)} href="?page={button}"
-					>{button}</a
-				>
+				<a href="?page={button}">{button}</a>
 			</li>
 		{:else}
 			<li class="ellipse">...</li>
@@ -62,9 +56,7 @@
 	{/each}
 	{#if currentPage < totalPages}
 		<li>
-			<a
-				on:click|preventDefault={() => goto(`?page=${currentPage + 1}`)}
-				href="?page={currentPage + 1}"
+			<a href="?page={currentPage + 1}"
 				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
 					<path d="M1 5H7l-3 -3M7 5l-3 3" />
 				</svg></a

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,13 +1,9 @@
 <script context="module" lang="ts">
 	const PAGE_SIZE = 50
 
-	export function paginate<T extends any[]>(pageParam: string | null, items: T) {
-		const number = pageParam ? parseInt(pageParam) : 1
+	export function paginate<T extends any[]>(number: number, items: T) {
 		const itemIndexStart = (number - 1) * PAGE_SIZE
-		return {
-			number,
-			items: items.slice(itemIndexStart, itemIndexStart + PAGE_SIZE) as T,
-		}
+		return items.slice(itemIndexStart, itemIndexStart + PAGE_SIZE) as T
 	}
 </script>
 

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-	const PAGE_SIZE = 50
+	const PAGE_SIZE = 25
 
 	export function paginate<T extends any[]>(number: number, items: T) {
 		const itemIndexStart = (number - 1) * PAGE_SIZE

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,0 +1,131 @@
+<script context="module" lang="ts">
+	export const PAGE_SIZE = 50
+</script>
+
+<script lang="ts">
+	import { goto } from '$app/navigation'
+	import { page } from '$app/stores'
+	export let current: number = 1
+	export let results: number
+
+	$: totalPages = Math.ceil(results / PAGE_SIZE)
+	$: buttons = createPageButtons(current, totalPages)
+
+	function createPageButtons(current: number, total: number) {
+		const buttons: (number | null)[] = []
+		const startPage = Math.max(1, Math.min(total - 4, current - 2))
+		const endPage = Math.min(total, startPage + 4)
+		for (let p = startPage; p <= endPage; p++) {
+			buttons.push(p)
+		}
+		if (startPage > 1) {
+			if (startPage - 1 > 1) buttons.unshift(null)
+			buttons.unshift(1)
+		}
+		if (endPage < total) {
+			if (endPage < total - 1) buttons.push(null)
+			buttons.push(total)
+		}
+		return buttons
+	}
+</script>
+
+<ul>
+	<li>{results} results</li>
+	{#if current > 1}
+		<li>
+			<a
+				on:click|preventDefault={() => goto(`?page=${current - 1}`)}
+				href="{$page.url.pathname}?page={current - 1}"
+				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
+					<path d="M7 5H1l3 -3M1 5l3 3" />
+				</svg></a
+			>
+		</li>
+	{/if}
+	{#each buttons as button}
+		{#if button}
+			<li class:current={button === current}>
+				<a
+					on:click|preventDefault={() => goto(`?page=${button}`)}
+					href="{$page.url.pathname}?page={button}">{button}</a
+				>
+			</li>
+		{:else}
+			<li class="ellipse">...</li>
+		{/if}
+	{/each}
+	{#if current < totalPages}
+		<li>
+			<a
+				on:click|preventDefault={() => goto(`?page=${current + 1}`)}
+				href="{$page.url.pathname}?page={current + 1}"
+				><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 10">
+					<path d="M1 5H7l-3 -3M7 5l-3 3" />
+				</svg></a
+			>
+		</li>
+	{/if}
+</ul>
+
+<style>
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		margin-top: var(--spacing);
+		display: flex;
+	}
+
+	ul li {
+		color: #9da1a4;
+		padding: 0 3px;
+		line-height: 20px;
+		font-weight: bold;
+	}
+
+	ul li:first-child {
+		padding-left: 0;
+		color: #696e72;
+		font-weight: normal;
+	}
+
+	ul li a {
+		color: #696e72;
+		padding: 0 6px;
+		display: inline-block;
+		line-height: 19px;
+		border-radius: 2px;
+		box-shadow: rgba(0, 0, 0, 0.25) 0 0 0 1px, rgba(255, 255, 255, 0.15) 0 1px 0 inset,
+			rgba(0, 0, 0, 0.25) 0 2px 2px;
+		text-shadow: rgba(255, 255, 255, 0.5) 0 1px 0;
+		-webkit-background-clip: padding;
+		-moz-background-clip: padding;
+		background-clip: padding-box;
+		background-color: #e6e6e6;
+		background-image: -webkit-linear-gradient(#f5f5f5, rgba(230, 230, 230, 0));
+		background-image: -moz-linear-gradient(#f5f5f5, rgba(230, 230, 230, 0));
+		background-image: -o-linear-gradient(#f5f5f5, rgba(230, 230, 230, 0));
+		background-image: linear-gradient(#f5f5f5, rgba(230, 230, 230, 0));
+		background-repeat: repeat-x;
+	}
+
+	ul li.current a {
+		box-shadow: #b5b5b5 0 0 0 1px, rgba(255, 255, 255, 0.15) 0 1px 0 inset,
+			rgba(0, 0, 0, 0.3) 0 1px 5px inset, #fff 0 2px 0;
+	}
+
+	ul li:not(.current) a:hover {
+		color: var(--color-gray);
+	}
+
+	ul li a svg {
+		height: 15px;
+		margin: 0 -1px;
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 1.75;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+	}
+</style>

--- a/src/routes/shows/[show]/[video]/+page.svelte
+++ b/src/routes/shows/[show]/[video]/+page.svelte
@@ -23,7 +23,7 @@
 		title={data.show.title}
 		rootUri="/shows/{data.show.id}"
 	/>
-	<Pagination results={data.videos.length} current={paginatedVideos.number} />
+	<Pagination totalResults={data.videos.length} currentPage={paginatedVideos.number} />
 </section>
 
 <style>

--- a/src/routes/shows/[show]/[video]/+page.svelte
+++ b/src/routes/shows/[show]/[video]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores'
-	import Pagination, { PAGE_SIZE } from '$lib/components/Pagination.svelte'
+	import Pagination, { paginate } from '$lib/components/Pagination.svelte'
 	import VideoEmbed from '$lib/components/VideoEmbed.svelte'
 	import VideoList from '$lib/components/VideoList.svelte'
 	import type { PageData } from './$types'
@@ -8,9 +8,7 @@
 	export let data: PageData
 
 	$: pageParam = $page.url.searchParams.get('page')
-	$: pageNumber = pageParam ? parseInt(pageParam) : 1
-	$: pageVideoIndexStart = (pageNumber - 1) * PAGE_SIZE
-	$: pageVideos = data.videos.slice(pageVideoIndexStart, pageVideoIndexStart + PAGE_SIZE)
+	$: paginatedVideos = paginate(pageParam, data.videos)
 </script>
 
 <h1 class="sr-only">{data.show.title}</h1>
@@ -20,8 +18,12 @@
 </section>
 
 <section class="container videos">
-	<VideoList videos={pageVideos} title={data.show.title} rootUri="/shows/{data.show.id}" />
-	<Pagination results={data.videos.length} current={pageNumber} />
+	<VideoList
+		videos={paginatedVideos.items}
+		title={data.show.title}
+		rootUri="/shows/{data.show.id}"
+	/>
+	<Pagination results={data.videos.length} current={paginatedVideos.number} />
 </section>
 
 <style>

--- a/src/routes/shows/[show]/[video]/+page.svelte
+++ b/src/routes/shows/[show]/[video]/+page.svelte
@@ -8,7 +8,8 @@
 	export let data: PageData
 
 	$: pageParam = $page.url.searchParams.get('page')
-	$: paginatedVideos = paginate(pageParam, data.videos)
+	$: pageNumber = pageParam ? parseInt(pageParam) : 1
+	$: paginatedVideos = paginate(pageNumber, data.videos)
 </script>
 
 <h1 class="sr-only">{data.show.title}</h1>
@@ -19,11 +20,11 @@
 
 <section class="container videos">
 	<VideoList
-		videos={paginatedVideos.items}
+		videos={paginatedVideos}
 		title={data.show.title}
 		rootUri="/shows/{data.show.id}"
 	/>
-	<Pagination totalResults={data.videos.length} currentPage={paginatedVideos.number} />
+	<Pagination totalResults={data.videos.length} currentPage={pageNumber} />
 </section>
 
 <style>

--- a/src/routes/shows/[show]/[video]/+page.svelte
+++ b/src/routes/shows/[show]/[video]/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
+	import { page } from '$app/stores'
+	import Pagination, { PAGE_SIZE } from '$lib/components/Pagination.svelte'
 	import VideoEmbed from '$lib/components/VideoEmbed.svelte'
 	import VideoList from '$lib/components/VideoList.svelte'
 	import type { PageData } from './$types'
 
 	export let data: PageData
+
+	$: pageParam = $page.url.searchParams.get('page')
+	$: pageNumber = pageParam ? parseInt(pageParam) : 1
+	$: pageVideoIndexStart = (pageNumber - 1) * PAGE_SIZE
+	$: pageVideos = data.videos.slice(pageVideoIndexStart, pageVideoIndexStart + PAGE_SIZE)
 </script>
 
 <h1 class="sr-only">{data.show.title}</h1>
@@ -13,7 +20,8 @@
 </section>
 
 <section class="container videos">
-	<VideoList videos={data.videos} title={data.show.title} rootUri="/shows/{data.show.id}" />
+	<VideoList videos={pageVideos} title={data.show.title} rootUri="/shows/{data.show.id}" />
+	<Pagination results={data.videos.length} current={pageNumber} />
 </section>
 
 <style>


### PR DESCRIPTION
This adds paginated videos and buttons to the bottom of the listing on show pages. (fixes #2)

The current page is read from a URL query parameter (`?page=1`). The two sites most relevant to this project do it the same exact way so I followed suit.

~~When a page is navigated to, we use SvelteKit's `goto` function to update the query param without reloading the entire page. A `href` to the page URL will be used as a fallback if JS is disabled (the site currently doesn't work without JS but whatever, best practice).~~

I chose a page size of 50, feel free to request a change.

I decided to handle pagination inside the `routes/shows/[show]/[video]` page instead of the `VideoList` component because the `VideoList` is used elsewhere where it doesn't need pagination, and because it's probably best to grab URL params on the actual page being requested instead of inside a component. The `Pagination` component exports a function to paginate any array of items for a given page param. I'm happy with the small amount of code necessary to use the component on any page, should we want to in the future.