### PR TITLE
Add a DataStore class

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -38,6 +38,37 @@ for (const video of videoData) {
 	}
 }
 
+export class DataStore {
+	readonly shows: { [key: string]: Show }
+	readonly videos: { [key: string]: Video }
+
+	constructor(showData: any[], videoData: any[]) {
+		this.shows = {}
+		for (const show of showData) {
+			this.shows[show.id] = {
+				id: show.id,
+				title: show.title,
+				description: show.description,
+				poster: show.poster,
+				logo: show.logo,
+				videos: show.videos,
+			}
+		}
+
+		this.videos = {}
+		for (const video of videoData) {
+			this.videos[video.id] = {
+				id: video.id,
+				title: video.title,
+				description: video.description,
+				date: new Date(video.date),
+				show: Object.values(shows).find((show) => show.videos.includes(video.id))?.id,
+				thumbnail: video.thumbnail,
+			}
+		}
+	}
+}
+
 const videoIndex: Map<string, string[]> = generateVideoIndex(Object.values(videos))
 
 // Sort by date descending

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -41,6 +41,7 @@ for (const video of videoData) {
 export class DataStore {
 	readonly shows: { [key: string]: Show }
 	readonly videos: { [key: string]: Video }
+	readonly videoIndex: Map<string, string[]>
 
 	constructor(showData: any[], videoData: any[]) {
 		this.shows = {}
@@ -64,6 +65,19 @@ export class DataStore {
 				date: new Date(video.date),
 				show: Object.values(shows).find((show) => show.videos.includes(video.id))?.id,
 				thumbnail: video.thumbnail,
+			}
+		}
+
+		this.videoIndex = new Map()
+		for (const video of videoData) {
+			const words = extractWords(video.title)
+
+			for (const word of words) {
+				if (!this.videoIndex.has(word)) {
+					this.videoIndex.set(word, [])
+				}
+
+				this.videoIndex.get(word).push(video.id)
 			}
 		}
 	}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,4 +1,4 @@
-import { getRandomShows, getVideosForDay, getVideosForShow } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { Show, Video } from '$lib/data'
 import type { PageLoad } from './$types'
 
@@ -12,13 +12,13 @@ interface ShowWithVideos extends Show {
 }
 
 export const load = (({ params }) => {
-	const shows = getRandomShows(3)
-	const historicVideos = pickNRandomVideos(getVideosForDay(), 4)
+	const shows = dataStore.getRandomShows(3)
+	const historicVideos = pickNRandomVideos(dataStore.getVideosForDay(), 4)
 
 	const filledShows: ShowWithVideos[] = shows.map((show) => {
 		return {
 			...show,
-			videoObjects: pickNRandomVideos(getVideosForShow(show), 4),
+			videoObjects: pickNRandomVideos(dataStore.getVideosForShow(show), 4),
 		}
 	})
 

--- a/src/routes/historic/+page.ts
+++ b/src/routes/historic/+page.ts
@@ -1,9 +1,9 @@
 import { error, redirect } from '@sveltejs/kit'
-import { getVideosForDay } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const videos = getVideosForDay()
+	const videos = dataStore.getVideosForDay()
 	if (videos.length === 0) throw error(404, 'Not found')
 
 	const shuffled = videos.sort(() => 0.5 - Math.random())

--- a/src/routes/historic/[video]/+page.ts
+++ b/src/routes/historic/[video]/+page.ts
@@ -1,13 +1,13 @@
 import { error } from '@sveltejs/kit'
-import { getVideoById, getVideosForDay } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const video = getVideoById(params.video)
+	const video = dataStore.getVideoById(params.video)
 
 	if (video === null) throw error(404, 'Not found')
 
-	const videos = getVideosForDay()
+	const videos = dataStore.getVideosForDay()
 
 	return { video, videos }
 }) satisfies PageLoad

--- a/src/routes/random/+page.ts
+++ b/src/routes/random/+page.ts
@@ -1,9 +1,9 @@
 import { error, redirect } from '@sveltejs/kit'
-import { getRandomVideos } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const video = getRandomVideos(1)[0]
+	const video = dataStore.getRandomVideos(1)[0]
 
 	throw redirect(302, `/random/${video.id}`)
 }) satisfies PageLoad

--- a/src/routes/random/[video]/+page.svelte
+++ b/src/routes/random/[video]/+page.svelte
@@ -2,15 +2,15 @@
 	import Button from '$lib/components/Button.svelte'
 	import VideoEmbed from '$lib/components/VideoEmbed.svelte'
 	import VideoList from '$lib/components/VideoList.svelte'
-	import { getRandomVideos } from '$lib/data'
+	import { dataStore } from '$lib/data'
 	import type { PageData } from './$types'
 
 	export let data: PageData
 
-	$: videos = getRandomVideos(12)
+	$: videos = dataStore.getRandomVideos(12)
 
 	function randomize() {
-		videos = getRandomVideos(12)
+		videos = dataStore.getRandomVideos(12)
 	}
 </script>
 

--- a/src/routes/random/[video]/+page.ts
+++ b/src/routes/random/[video]/+page.ts
@@ -1,9 +1,9 @@
 import { error } from '@sveltejs/kit'
-import { getVideoById } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const video = getVideoById(params.video)
+	const video = dataStore.getVideoById(params.video)
 
 	if (video === null) throw error(404, 'Not found')
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Button from '$lib/components/Button.svelte'
 	import VideoList from '$lib/components/VideoList.svelte'
-	import { searchVideos } from '$lib/data'
+	import { dataStore } from '$lib/data'
 	import type { Video } from '$lib/data'
 
 	let videos: Video[]
@@ -11,7 +11,7 @@
 
 	//TODO debounce (trailing edge) this function
 	const searchSubmit = () => {
-		videos = searchQuery === '' ? [] : searchVideos(searchQuery)
+		videos = searchQuery === '' ? [] : dataStore.searchVideos(searchQuery)
 	}
 </script>
 

--- a/src/routes/shows/+page.ts
+++ b/src/routes/shows/+page.ts
@@ -1,8 +1,8 @@
-import { getShows } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const shows = getShows()
+	const shows = dataStore.getShows()
 	return { shows }
 }) satisfies PageLoad
 

--- a/src/routes/shows/[show]/+page.ts
+++ b/src/routes/shows/[show]/+page.ts
@@ -1,13 +1,13 @@
 import { error, redirect } from '@sveltejs/kit'
-import { getShowById, getVideosForShow } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const show = getShowById(params.show)
+	const show = dataStore.getShowById(params.show)
 
 	if (show === null) throw error(404, 'Not found')
 
-	const videos = getVideosForShow(show)
+	const videos = dataStore.getVideosForShow(show)
 	if (videos.length === 0) throw error(404, 'Not found')
 
 	const video = videos[0]

--- a/src/routes/shows/[show]/[video]/+page.ts
+++ b/src/routes/shows/[show]/[video]/+page.ts
@@ -1,15 +1,15 @@
 import { error } from '@sveltejs/kit'
-import { getShowById, getVideoById, getVideosForShow } from '$lib/data'
+import { dataStore } from '$lib/data'
 import type { PageLoad } from './$types'
 
 export const load = (({ params }) => {
-	const show = getShowById(params.show)
+	const show = dataStore.getShowById(params.show)
 
 	if (show === null) throw error(404, 'Not found')
 
-	const videos = getVideosForShow(show)
+	const videos = dataStore.getVideosForShow(show)
 
-	const video = getVideoById(params.video)
+	const video = dataStore.getVideoById(params.video)
 	if (video === null) throw error(404, 'Not found')
 
 	return { show, video, videos }

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -169,6 +169,47 @@ describe('DataStore', () => {
 			expect(dataStore.shows).toStrictEqual(expectedShows)
 			expect(dataStore.videos).toStrictEqual(expectedVideos)
 		})
+
+		it('generates a video index', () => {
+			const videoData: Video[] = [
+				{
+					id: 'mfv',
+					title: 'My Fancy Video',
+					description: 'Description.',
+					date: new Date(),
+					show: undefined,
+					thumbnail: undefined,
+				},
+				{
+					id: 'vgab',
+					title: 'Video Games Are Bad',
+					description: 'Description.',
+					date: new Date(),
+					show: undefined,
+					thumbnail: undefined,
+				},
+				{
+					id: 'mbv',
+					title: 'My Bad Video',
+					description: 'Description.',
+					date: new Date(),
+					show: undefined,
+					thumbnail: undefined,
+				},
+			]
+			const expected = new Map(Object.entries({
+				my: ['mfv', 'mbv'],
+				fancy: ['mfv'],
+				video: ['mfv', 'vgab', 'mbv'],
+				games: ['vgab'],
+				are: ['vgab'],
+				bad: ['vgab', 'mbv'],
+			}));
+
+			const dataStore = new DataStore([], videoData)
+
+			expect(dataStore.videoIndex).toStrictEqual(expected)
+		})
 	})
 })
 

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -1,7 +1,176 @@
 // sum.test.js
 import { describe, it, expect } from 'vitest'
-import { generateVideoIndex } from '$lib/data'
+import { generateVideoIndex, DataStore } from '$lib/data'
 import type { Video } from '$lib/data'
+
+const testShowData = [
+	{
+		id: 'this-aint-no-game',
+		title: "This Ain't No Game",
+		description:
+			'Your look into the world of video game movies and the Wonderful Universe of movies with video game themes.',
+		poster: '3026329-gb_default-16_9.jpg',
+		logo: null,
+		videos: [
+			'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+			'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+			'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+			'2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I',
+		],
+	},
+	{
+		id: 'cross-coast',
+		title: 'Cross Coast',
+		description: 'We join forces across the country to overcome all obstacles.',
+		poster: '3171039-crosscoast.png',
+		logo: '3171040-crosscoast_transparent.png',
+		videos: ['gb-2300-15259-IDJIYS2', 'gb-2300-16398-IDJKE0C'],
+	},
+]
+const testVideoData = [
+	{
+		id: 'gb-2300-15259-IDJIYS2',
+		title: 'Cross Coast: Red Dead Redemption 2 (03/02/2020)',
+		description: "Let's posse up and see what's new in the world of Red Dead.",
+		date: '2020-03-02T00:00:00Z',
+		thumbnail: 'https://archive.org/services/img/gb-2300-15259-IDJIYS2',
+	},
+	{
+		id: 'gb-2300-16398-IDJKE0C',
+		title: "Cross Coast: Abby's Not-Goodbye-But-See-You-Later Stream!",
+		description:
+			'Join us as we wish Abby well using full sentences, one word, and eventually questionable hand gestures.',
+		date: '2020-11-25T00:00:00Z',
+		thumbnail: 'https://archive.org/services/img/gb-2300-16398-IDJKE0C',
+	},
+	{
+		id: '2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+		title: "This Ain't No Game: Double Dragon",
+		description: "Ryan kicks off his movie tour with this...well...it's definitely a movie.",
+		date: '2009-02-11T00:00:00Z',
+		thumbnail:
+			'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+	},
+	{
+		id: '2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+		title: "This Ain't No Game: Street Fighter",
+		description:
+			"In honor of Street Fighter IV's release, we're sharing this epic piece of cinema.",
+		date: '2009-02-19T00:00:00Z',
+		thumbnail:
+			'https://archive.org/services/img/2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+	},
+	{
+		id: '2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+		title: "This Ain't No Game: Resident Evil",
+		description: 'Ryan finds some love for the master of anti-dog karate.',
+		date: '2009-02-26T00:00:00Z',
+		thumbnail:
+			'https://archive.org/services/img/2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+	},
+	{
+		id: '2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I',
+		title: "This Ain't No Game: TANG: Final Fantasy VII Advent Children",
+		description: 'Ryan dives deep into this tale of love, loss, and Sephiroth.',
+		date: '2009-03-05T00:00:00Z',
+		thumbnail:
+			'https://archive.org/services/img/2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I',
+	},
+]
+
+describe('DataStore', () => {
+	describe('constructor', () => {
+		it('creates a DataStore based on video and show data', () => {
+			const expectedShows = {
+				'cross-coast': {
+					id: 'cross-coast',
+					title: 'Cross Coast',
+					description: 'We join forces across the country to overcome all obstacles.',
+					poster: '3171039-crosscoast.png',
+					logo: '3171040-crosscoast_transparent.png',
+					videos: ['gb-2300-15259-IDJIYS2', 'gb-2300-16398-IDJKE0C'],
+				},
+				'this-aint-no-game': {
+					id: 'this-aint-no-game',
+					title: "This Ain't No Game",
+					description:
+						'Your look into the world of video game movies and the Wonderful Universe of movies with video game themes.',
+					poster: '3026329-gb_default-16_9.jpg',
+					logo: null,
+					videos: [
+						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I',
+					],
+				},
+			}
+			const expectedVideos = {
+				'gb-2300-15259-IDJIYS2': {
+					id: 'gb-2300-15259-IDJIYS2',
+					title: 'Cross Coast: Red Dead Redemption 2 (03/02/2020)',
+					description: "Let's posse up and see what's new in the world of Red Dead.",
+					date: new Date('2020-03-02T00:00:00Z'),
+					thumbnail: 'https://archive.org/services/img/gb-2300-15259-IDJIYS2',
+					show: 'cross-coast',
+				},
+				'gb-2300-16398-IDJKE0C': {
+					id: 'gb-2300-16398-IDJKE0C',
+					title: "Cross Coast: Abby's Not-Goodbye-But-See-You-Later Stream!",
+					description:
+						'Join us as we wish Abby well using full sentences, one word, and eventually questionable hand gestures.',
+					date: new Date('2020-11-25T00:00:00Z'),
+					thumbnail: 'https://archive.org/services/img/gb-2300-16398-IDJKE0C',
+					show: 'cross-coast',
+				},
+				'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY': {
+					id: '2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+					title: "This Ain't No Game: Double Dragon",
+					description:
+						"Ryan kicks off his movie tour with this...well...it's definitely a movie.",
+					date: new Date('2009-02-11T00:00:00Z'),
+					thumbnail:
+						'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+					show: 'this-aint-no-game',
+				},
+				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N': {
+					id: '2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+					title: "This Ain't No Game: Street Fighter",
+					description:
+						"In honor of Street Fighter IV's release, we're sharing this epic piece of cinema.",
+					date: new Date('2009-02-19T00:00:00Z'),
+					thumbnail:
+						'https://archive.org/services/img/2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+					show: 'this-aint-no-game',
+				},
+				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY': {
+					id: '2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+					title: "This Ain't No Game: Resident Evil",
+					description: 'Ryan finds some love for the master of anti-dog karate.',
+					date: new Date('2009-02-26T00:00:00Z'),
+					thumbnail:
+						'https://archive.org/services/img/2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+					show: 'this-aint-no-game',
+				},
+				'2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I':
+					{
+						id: '2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I',
+						title: "This Ain't No Game: TANG: Final Fantasy VII Advent Children",
+						description: 'Ryan dives deep into this tale of love, loss, and Sephiroth.',
+						date: new Date('2009-03-05T00:00:00Z'),
+						thumbnail:
+							'https://archive.org/services/img/2009-03-05-This_Aint_No_Game-This_Aint_No_Game_TANG_Final_Fantasy_VII_Advent_Children-IDP0ST4I',
+						show: 'this-aint-no-game',
+					},
+			}
+
+			const dataStore = new DataStore(testShowData, testVideoData)
+
+			expect(dataStore.shows).toStrictEqual(expectedShows)
+			expect(dataStore.videos).toStrictEqual(expectedVideos)
+		})
+	})
+})
 
 describe('generateVideoIndex', () => {
 	it('creates an index of videos based on a list', () => {

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -1,6 +1,6 @@
 // sum.test.js
 import { describe, it, expect } from 'vitest'
-import { generateVideoIndex, DataStore } from '$lib/data'
+import { DataStore } from '$lib/data'
 import type { Video } from '$lib/data'
 
 const testShowData = [
@@ -210,47 +210,5 @@ describe('DataStore', () => {
 
 			expect(dataStore.videoIndex).toStrictEqual(expected)
 		})
-	})
-})
-
-describe('generateVideoIndex', () => {
-	it('creates an index of videos based on a list', () => {
-		const videos: Video[] = [
-			{
-				id: 'mfv',
-				title: 'My Fancy Video',
-				description: 'Description.',
-				date: new Date(),
-				show: undefined,
-				thumbnail: undefined,
-			},
-			{
-				id: 'vgab',
-				title: 'Video Games Are Bad',
-				description: 'Description.',
-				date: new Date(),
-				show: undefined,
-				thumbnail: undefined,
-			},
-			{
-				id: 'mbv',
-				title: 'My Bad Video',
-				description: 'Description.',
-				date: new Date(),
-				show: undefined,
-				thumbnail: undefined,
-			},
-		]
-		const expected: Map<string, string[]> = new Map()
-		expected.set('my', ['mfv', 'mbv'])
-		expected.set('fancy', ['mfv'])
-		expected.set('video', ['mfv', 'vgab', 'mbv'])
-		expected.set('games', ['vgab'])
-		expected.set('are', ['vgab'])
-		expected.set('bad', ['vgab', 'mbv'])
-
-		const result = generateVideoIndex(videos)
-
-		expect(result).toStrictEqual(expected)
 	})
 })

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -197,18 +197,112 @@ describe('DataStore', () => {
 					thumbnail: undefined,
 				},
 			]
-			const expected = new Map(Object.entries({
-				my: ['mfv', 'mbv'],
-				fancy: ['mfv'],
-				video: ['mfv', 'vgab', 'mbv'],
-				games: ['vgab'],
-				are: ['vgab'],
-				bad: ['vgab', 'mbv'],
-			}));
+			const expected = new Map(
+				Object.entries({
+					my: ['mfv', 'mbv'],
+					fancy: ['mfv'],
+					video: ['mfv', 'vgab', 'mbv'],
+					games: ['vgab'],
+					are: ['vgab'],
+					bad: ['vgab', 'mbv'],
+				})
+			)
 
 			const dataStore = new DataStore([], videoData)
 
 			expect(dataStore.videoIndex).toStrictEqual(expected)
+		})
+	})
+
+	describe('getRandomShows', () => {
+		it('gets a list of N random shows', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+
+			for (var i = 0; i < 5; i++) {
+				const result = dataStore.getRandomShows(1)
+
+				expect(result.length).toBe(1)
+				expect(testShowData.map((x) => x.id)).toContain(result[0].id)
+			}
+		})
+	})
+
+	describe('getRandomVideos', () => {
+		it('gets a list of N random videos', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+
+			for (var i = 0; i < 5; i++) {
+				const result = dataStore.getRandomVideos(2)
+
+				expect(result.length).toBe(2)
+				expect(testVideoData.map((x) => x.id)).toContain(result[0].id)
+				expect(testVideoData.map((x) => x.id)).toContain(result[1].id)
+			}
+		})
+	})
+
+	describe('getShowById', () => {
+		it('gets a specific show', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+			const result = dataStore.getShowById('this-aint-no-game')
+
+			expect(result).toStrictEqual(dataStore.shows['this-aint-no-game'])
+		})
+	})
+
+	describe('getShows', () => {
+		it('gets a list of all shows', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+			const result = dataStore.getShows()
+
+			expect(result.map((x) => x.id)).toStrictEqual(['cross-coast', 'this-aint-no-game'])
+		})
+	})
+
+	describe('getVideoById', () => {
+		it('gets a specific show', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+			const result = dataStore.getVideoById(
+				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N'
+			)
+
+			expect(result).toStrictEqual(
+				dataStore.videos[
+					'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N'
+				]
+			)
+		})
+	})
+
+	describe('getVideosForDay', () => {
+		it('gets a specific show', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+			const result = dataStore.getVideosForDay(new Date('2023-11-25T00:00:00Z'))
+
+			expect(result.map((x) => x.id)).toStrictEqual(['gb-2300-16398-IDJKE0C'])
+		})
+	})
+
+	describe('getVideosForShow', () => {
+		it('gets a specific show', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+			const result = dataStore.getVideosForShow(dataStore.shows['cross-coast'])
+
+			expect(result.map((x) => x.id)).toStrictEqual([
+				'gb-2300-16398-IDJKE0C',
+				'gb-2300-15259-IDJIYS2',
+			])
+		})
+	})
+
+	describe('searchVideos', () => {
+		it('gets a specific show', () => {
+			const dataStore = new DataStore(testShowData, testVideoData)
+			const result = dataStore.searchVideos('evil')
+
+			expect(result.map((x) => x.id)).toStrictEqual([
+				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+			])
 		})
 	})
 })


### PR DESCRIPTION
This adds a `DataStore` class which contains all the functions used to get shows and videos. My reasoning behind doing this was to make it easier to test the functions themselves. The class is constructed using video and show data, so it's then possible to create a data store with specific test data rather than having to use the entire list every time.

The page itself should not have changed at all.