### PR TITLE
Fix video links in VideoList component

### DIFF
--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -66,7 +66,7 @@
 <ul class={currentMode}>
 	{#each videos as video}
 		<li>
-			<a href="{rootUri || `shows/${video.show}`}/{video.id}">
+			<a href="{rootUri || `/shows/${video.show}`}/{video.id}">
 				<div class="thumbnail">
 					<Thumbnail src={video.thumbnail || '/assets/default.jpg'} alt="" />
 				</div>


### PR DESCRIPTION
We missed a bug introduced in the [search page PR](https://github.com/Giant-Bomb-Preservation-Project/duders-zone/pull/19), specifically [this line](https://github.com/Giant-Bomb-Preservation-Project/duders-zone/pull/19/files#diff-dacca0324023536303f4e9a3b0fea3405a7103da6440b59df47112f182bcd17fR69).

The `rootUri` parameter should fall back to a default of `/shows/...` but instead it was missing that prefix slash, which made it a relative link, causing navigation to invalid URLs like `https://duders.zone/shows/unprofessional-fridays/shows/unprofessional-fridays/gb-2300-16641-ID4LVB9`

This PR adds that slash back in.

Thanks to arbiter074 in the Discord for reporting this bug.