### PR TITLE
Add Pagination component to VideoList

### DIFF
--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <ul>
-	<li>{totalResults} results</li>
+	<li>{totalResults} videos</li>
 	{#if currentPage > 1}
 		<li>
 			<a href="?page={currentPage - 1}" aria-label="Previous Page"

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,21 +1,12 @@
-<script module lang="ts">
-	const PAGE_SIZE = 24
-
-	export function paginate<T extends any[]>(number: number, items: T) {
-		const itemIndexStart = (number - 1) * PAGE_SIZE
-		return items.slice(itemIndexStart, itemIndexStart + PAGE_SIZE) as T
-	}
-</script>
-
 <script lang="ts">
 	interface Props {
-		currentPage?: number
+		currentPage: number
+		totalPages: number
 		totalResults: number
 	}
 
-	const { currentPage = 1, totalResults }: Props = $props()
+	const { currentPage, totalPages, totalResults }: Props = $props()
 
-	const totalPages = Math.ceil(totalResults / PAGE_SIZE)
 	const buttons = $derived(createPageButtons(currentPage, totalPages))
 
 	// Creates the list of which pages should show up as buttons (with null being ... separators)

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -35,7 +35,6 @@
 		const itemIndexStart = (pageNumber - 1) * perPage
 		return videos.slice(itemIndexStart, itemIndexStart + perPage)
 	})
-	let linkSuffix = $derived(pageNumber != 1 ? '?page=' + pageNumber : '')
 </script>
 
 <Header {title}>
@@ -77,7 +76,7 @@
 <ul class={mode ?? $videoListMode}>
 	{#each paginatedVideos as video}
 		<li>
-			<a href="{rootUri || `/shows/${video.show}`}/{video.id}{linkSuffix}">
+			<a href="{rootUri || `/shows/${video.show}`}/{video.id}">
 				<div class="thumbnail">
 					<Thumbnail src={video.thumbnail || '/assets/default.jpg'} alt="" />
 				</div>

--- a/src/routes/shows/[show]/[video]/+page.svelte
+++ b/src/routes/shows/[show]/[video]/+page.svelte
@@ -9,7 +9,6 @@
 	}
 
 	const { data }: Props = $props()
-	let pageNumber = $derived(data.pageNumber)
 </script>
 
 <h1 class="sr-only">{data.show.title}</h1>
@@ -19,7 +18,12 @@
 </section>
 
 <section class="container videos">
-	<VideoList videos={data.videos} title={data.show.title} perPage={24} {pageNumber} />
+	<VideoList
+		videos={data.videos}
+		title={data.show.title}
+		perPage={data.perPage}
+		pageNumber={data.pageNumber}
+	/>
 </section>
 
 <svelte:head>

--- a/src/routes/shows/[show]/[video]/+page.svelte
+++ b/src/routes/shows/[show]/[video]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { page } from '$app/stores'
-	import Pagination, { paginate } from '$lib/components/Pagination.svelte'
 	import VideoEmbed from '$lib/components/VideoEmbed.svelte'
 	import VideoList from '$lib/components/VideoList.svelte'
 	import type { PageData } from './$types'
@@ -11,7 +10,6 @@
 
 	const { data }: Props = $props()
 	let pageNumber = $derived(data.pageNumber)
-	let paginatedVideos = $derived(paginate(pageNumber, data.videos))
 </script>
 
 <h1 class="sr-only">{data.show.title}</h1>
@@ -21,12 +19,7 @@
 </section>
 
 <section class="container videos">
-	<VideoList
-		videos={paginatedVideos}
-		title={data.show.title}
-		linkSuffix={`?page=${pageNumber}`}
-	/>
-	<Pagination totalResults={data.videos.length} currentPage={pageNumber} />
+	<VideoList videos={data.videos} title={data.show.title} perPage={24} {pageNumber} />
 </section>
 
 <svelte:head>

--- a/src/routes/shows/[show]/[video]/+page.ts
+++ b/src/routes/shows/[show]/[video]/+page.ts
@@ -13,9 +13,21 @@ export const load = (({ params, url }) => {
 	const video = dataStore.getVideoById(params.video)
 	if (video === null) throw error(404, 'Not found')
 
-	const pageNumber: number = browser ? parseInt(url.searchParams.get('page') ?? '1') : 1
+	const perPage = 24
+	let pageNumber: number = 1
+	if (browser && url.searchParams.get('page')) {
+		pageNumber = parseInt(url.searchParams.get('page') ?? '1') || 1
+	} else {
+		// Determine which page the current video is on
+		for (let i = 0; i < videos.length; i++) {
+			if (videos[i].id === video.id) {
+				pageNumber = Math.floor(i / perPage) + 1
+				break
+			}
+		}
+	}
 
-	return { show, video, videos, pageNumber }
+	return { show, video, videos, pageNumber, perPage }
 }) satisfies PageLoad
 
 export const entries: EntryGenerator = () => {


### PR DESCRIPTION
This puts the pagination element at the bottom of every video list so that it will enumerate the videos, even if things aren't paginated:

<img width="300" alt="Screenshot 2025-04-29 at 18 52 11" src="https://github.com/user-attachments/assets/4539dd86-707c-45f1-b8c0-a48bb326ac5f" />

If the `perPage` property is sent in it will split the videos (if need be) and show pagination links. This is essentially just used on the canonical video page, showing the other videos from the same show.

Another feature is that it will determine which page that a video belongs to and start on that page when you navigate to the video.