### PR TITLE
Hide pagination in the VideoList if the "Show All" link is active

### DIFF
--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -93,7 +93,9 @@
 	{/each}
 </ul>
 
-<Pagination totalResults={videos.length} currentPage={pageNumber} {totalPages} />
+{#if !seeAllUrl}
+	<Pagination totalResults={videos.length} currentPage={pageNumber} {totalPages} />
+{/if}
 
 <style>
 	h3 {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,11 +9,11 @@ const config = {
 
 	kit: {
 		adapter: adapter({
-			fallback: '404.html'
+			fallback: '404.html',
 		}),
 		paths: {
-			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
-		}
+			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH,
+		},
 	},
 }
 


### PR DESCRIPTION
This is to fix the ugly issue that's showing up on the front page where the amount of videos is appearing over the "Show me more" button:

<img width="942" alt="Screenshot 2025-05-02 at 00 12 48" src="https://github.com/user-attachments/assets/70e8c9f4-0b38-4680-b2ab-888a9a6ef482" />

The `<VideoList>` component feels like it's doing a bit too much at this point, so it may need to be refactored, but that can wait.
