### PR TITLE
Add analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
             - name: build
               env:
                   BASE_PATH: ''
+                  VITE_PLAUSIBLE_HOST: ${{ vars.PLAUSIBLE_HOST }}
               run: |
                   npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@sveltejs/kit": "^2.20.7",
 				"@sveltejs/vite-plugin-svelte": "^5.0.3",
 				"axios": "^1.8.4",
+				"plausible-tracker": "^0.3.9",
 				"prettier": "^3.5.3",
 				"prettier-plugin-svelte": "^3.3.3",
 				"svelte": "^5.28.2",
@@ -1287,6 +1288,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/plausible-tracker": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.9.tgz",
+			"integrity": "sha512-hMhneYm3GCPyQon88SZrVJx+LlqhM1kZFQbuAgXPoh/Az2YvO1B6bitT9qlhpiTdJlsT5lsr3gPmzoVjb5CDXA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@sveltejs/kit": "^2.20.7",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"axios": "^1.8.4",
+		"plausible-tracker": "^0.3.9",
 		"prettier": "^3.5.3",
 		"prettier-plugin-svelte": "^3.3.3",
 		"svelte": "^5.28.2",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,10 +2,12 @@
 	import type { Snippet } from 'svelte'
 	import { base } from '$app/paths'
 	import { page } from '$app/stores'
+	import { browser } from '$app/environment'
 	import logo from '$lib/images/logo-dz.png'
 	import internetArchive from '$lib/images/internet-archive.jpg'
 	import giantBombPreservationSociety from '$lib/images/giant-bomb-preservation-society.png'
 	import '../app.css'
+	import Plausible from 'plausible-tracker'
 
 	interface Props {
 		children?: Snippet
@@ -19,6 +21,14 @@
 		{ path: `${base}/random`, text: 'Random' },
 		{ path: `${base}/alumni`, text: 'Alumni' },
 	]
+
+	if (browser && import.meta.env.VITE_PLAUSIBLE_HOST) {
+		const { enableAutoPageviews } = Plausible({
+			domain: 'duders.zone',
+			apiHost: import.meta.env.VITE_PLAUSIBLE_HOST,
+		})
+		enableAutoPageviews()
+	}
 </script>
 
 <div id="site-container">


### PR DESCRIPTION
This adds basic hit tracking provided by [Plausible Analytics](https://plausible.io/), privacy focused and open source web analytics. [Plausible does not use cookies or collect any PII](https://plausible.io/data-policy).

I'm hosting an instance of Plausible CE (the self-hosted "community edition") which provides the back and front end of the tracking. Page views are tracked by sending requests to my server. The URL of this, while technically not private, is stored in an environment variable of this repo, which gets called as part of the build action. That just keeps the source code tidy.