### PR TITLE
Add an "Uncategorized" show for videos missing a show

### DIFF
--- a/scripts/sources/InternetArchive.ts
+++ b/scripts/sources/InternetArchive.ts
@@ -11,11 +11,22 @@ const UNWANTED_SUBJECTS = ['Giant Bomb']
 
 export interface ArchiveCollectionItem {
 	identifier: string
+	guid: string | null
 	mediatype: string
 	date: Date
 	description: string
 	subject: Array<string>
 	title: string
+}
+
+function extractGuid(item: object): string | null {
+	if (!('external-identifier' in item)) {
+		return null
+	}
+
+	const match = item['external-identifier'].toLowerCase().match(/^gb-guid:(.+)$/)
+
+	return match ? match[1] : null
 }
 
 // Gets data from the Internet Archive API
@@ -32,7 +43,7 @@ export default class InternetArchive {
 		const params = {
 			q: `collection:${identifier}`,
 			count: REQUEST_LIMIT,
-			fields: 'identifier,date,title,description,mediatype,subject',
+			fields: 'identifier,date,title,description,mediatype,subject,external-identifier',
 		}
 
 		let total = -1
@@ -62,6 +73,7 @@ export default class InternetArchive {
 						: item.subject
 				items.push({
 					identifier: item.identifier,
+					guid: extractGuid(item),
 					mediatype: item.mediatype,
 					date: item.date ? new Date(item.date) : null,
 					description: item.description,

--- a/scripts/sync_data.ts
+++ b/scripts/sync_data.ts
@@ -21,6 +21,9 @@ const VIDEOS_FILE_PATH = 'src/lib/data/videos.json'
 // Path to the location to store the show images
 const SHOW_IMAGES_PATH = 'static/assets/shows/'
 
+// ID of the show which holds the uncategorized videos
+const UNCATEGORIZED_SHOW_ID = 'uncategorized'
+
 ///
 /// Helper functions
 ///
@@ -194,6 +197,17 @@ async function run() {
 		}
 	}
 
+	// Add a fake show to hold all the videos that don't have shows
+	shows.push({
+		id: UNCATEGORIZED_SHOW_ID,
+		gb_id: null,
+		title: 'Uncategorized',
+		description: 'For all the videos that have no show of their own.',
+		poster: null,
+		logo: null,
+		videos: [],
+	})
+
 	// Process videos
 
 	log(`Adding ${gbVideos.length} IA videos...`)
@@ -252,10 +266,9 @@ async function run() {
 			}
 		}
 
-		// Video has no shows at all???
+		// Video has no shows at all
 		if (videoShows.size === 0) {
-			log('error', `Skipping video due to missing show: ${video.name} (${video.id})`)
-			continue // TODO: what to do?
+			videoShows.add(UNCATEGORIZED_SHOW_ID)
 		}
 
 		// Setup the video sources
@@ -304,8 +317,7 @@ async function run() {
 		}
 
 		if (videoShows.length === 0) {
-			log('error', `Skipping video due to missing show: ${video.title} (${video.identifier})`)
-			continue // TODO: what to do?
+			videoShows.push(UNCATEGORIZED_SHOW_ID)
 		}
 
 		videos.push({

--- a/scripts/sync_data.ts
+++ b/scripts/sync_data.ts
@@ -210,7 +210,7 @@ async function run() {
 
 	// Process videos
 
-	log(`Adding ${gbVideos.length} IA videos...`)
+	log(`Adding ${gbVideos.length} GB videos...`)
 	for (const video of gbVideos) {
 		const videoShows = new Set()
 
@@ -225,29 +225,34 @@ async function run() {
 			videoShows.add(show.id)
 		}
 
-		// Find the IA video for this video
-		const iaVideoIndex = iaItems.findIndex((item) => {
-			let score = 0
+		// Find the IA video for this video using the GUID
+		let iaVideoIndex = iaItems.findIndex((item) => (item.guid === video.guid))
 
-			score += item.title.replaceAll(' ', '').includes(video.name.replaceAll(' ', '')) ? 1 : 0
-			score +=
-				item.description &&
-				item.description.replaceAll(' ', '').includes(video.description.replaceAll(' ', ''))
-					? 1
-					: 0
-			score += item.identifier.includes(video.guid) ? 1 : 0
-			if (item.date) {
+		if (iaVideoIndex === -1) {
+			// Find the IA video for this video using metadata matching
+			iaVideoIndex = iaItems.findIndex((item) => {
+				let score = 0
+
+				score += item.title.replaceAll(' ', '').includes(video.name.replaceAll(' ', '')) ? 1 : 0
 				score +=
-					item.date.toISOString().substring(0, 10) ==
-					video.publish_date.toISOString().substring(0, 10)
+					item.description &&
+					item.description.replaceAll(' ', '').includes(video.description.replaceAll(' ', ''))
 						? 1
 						: 0
-			}
+				score += item.identifier.includes(video.guid) ? 1 : 0
+				if (item.date) {
+					score +=
+						item.date.toISOString().substring(0, 10) ==
+						video.publish_date.toISOString().substring(0, 10)
+							? 1
+							: 0
+				}
 
-			return score >= 2 // probably the right video
-		})
-		const iaVideo = iaVideoIndex != -1 ? iaItems[iaVideoIndex] : null
+				return score >= 2 // probably the right video
+			})
+		}
 
+		const iaVideo = iaVideoIndex !== -1 ? iaItems[iaVideoIndex] : null
 		if (iaVideo) {
 			// Add the IA subjects to the show list
 			for (const subject of iaVideo.subject) {

--- a/scripts/sync_data.ts
+++ b/scripts/sync_data.ts
@@ -116,7 +116,7 @@ async function run() {
 
 	// Load data
 
-	const gb = new GiantBomb(process.env.GB_API_KEY)
+	const gb = new GiantBomb(process.env.GB_API_KEY, 1)
 	const ia = new InternetArchive()
 
 	log('Getting items from Internet Archive...')

--- a/scripts/sync_data.ts
+++ b/scripts/sync_data.ts
@@ -226,17 +226,21 @@ async function run() {
 		}
 
 		// Find the IA video for this video using the GUID
-		let iaVideoIndex = iaItems.findIndex((item) => (item.guid === video.guid))
+		let iaVideoIndex = iaItems.findIndex((item) => item.guid === video.guid)
 
 		if (iaVideoIndex === -1) {
 			// Find the IA video for this video using metadata matching
 			iaVideoIndex = iaItems.findIndex((item) => {
 				let score = 0
 
-				score += item.title.replaceAll(' ', '').includes(video.name.replaceAll(' ', '')) ? 1 : 0
+				score += item.title.replaceAll(' ', '').includes(video.name.replaceAll(' ', ''))
+					? 1
+					: 0
 				score +=
 					item.description &&
-					item.description.replaceAll(' ', '').includes(video.description.replaceAll(' ', ''))
+					item.description
+						.replaceAll(' ', '')
+						.includes(video.description.replaceAll(' ', ''))
 						? 1
 						: 0
 				score += item.identifier.includes(video.guid) ? 1 : 0

--- a/src/lib/data/shows.json
+++ b/src/lib/data/shows.json
@@ -3751,8 +3751,11 @@
             "2300-19596",
             "2300-19592",
             "2300-19583",
+            "2300-19578",
             "2300-19577",
+            "2300-19570",
             "2300-19569",
+            "2300-19568",
             "2300-19567",
             "2300-19555",
             "2300-19549",
@@ -4654,7 +4657,7 @@
             "2300-10112",
             "2300-10084",
             "2300-10033",
-            "gb-2300-18310-IDLT88J",
+            "gb-2300-18309-IDVKR1T",
             "gb-Unarchived0002-IDJRO2O",
             "gb-Unarchived0143-IDIDXUM",
             "gb-Unarchived8725"
@@ -6702,7 +6705,9 @@
             "2300-19619",
             "2300-19605",
             "2300-19604",
+            "2300-19589",
             "2300-19588",
+            "2300-19574",
             "2300-19575",
             "2300-19561",
             "2300-19547",
@@ -9957,8 +9962,8 @@
             "2300-18028",
             "2300-18014",
             "2023-05-04-b-lite-club-may-the-fourth-be-with-you",
-            "gb-2300-18924-IDFO68P",
-            "gb-2300-19128-IDDPTZQ"
+            "blight-club-grubbkatana-07",
+            "gb-2300-18924-IDFO68P"
         ]
     },
     {
@@ -11158,7 +11163,7 @@
             "2300-3838",
             "2300-3819",
             "2300-3784",
-            "2300-6648",
+            "2012-10-04-thursday-night-throwdown-thursday-night-throwdown-10-04-12",
             "gb-Unarchived0045-ID4PEP3",
             "gb-Unarchived0046-IDO1PLA",
             "gb-Unarchived0047-IDILHSM",
@@ -11793,7 +11798,8 @@
             "gb-Unarchived0140-IDYKSY2",
             "gb-Unarchived0145-ID850SD",
             "gb-Unarchived8728",
-            "giant_bomb_countdown_bumper"
+            "giant_bomb_countdown_bumper",
+            "whiskey-media-moving-day"
         ]
     },
     {
@@ -13798,6 +13804,18 @@
         "videos": [
             "2300-9883",
             "2300-9882"
+        ]
+    },
+    {
+        "id": "uncategorized",
+        "gb_id": null,
+        "title": "Uncategorized",
+        "description": "For all the videos that have no show of their own.",
+        "poster": null,
+        "logo": null,
+        "videos": [
+            "2300-18530",
+            "2300-7986"
         ]
     }
 ]


### PR DESCRIPTION
There were two shows that didn't have shows associated with them and were just being skipped over. Now they have a show all to their own.

<img width="703" alt="Screenshot 2025-05-03 at 23 16 18" src="https://github.com/user-attachments/assets/f16f74c3-9837-4f82-84df-e062a2c53e88" />

This PR also includes fetching the `'external-identifier'` from Internet Archive and trying to use that to match videos first, before using the shaky title/description matching.