### PR TITLE
Some small stylistic tweaks

### DIFF
--- a/src/lib/components/Thumbnail.svelte
+++ b/src/lib/components/Thumbnail.svelte
@@ -23,20 +23,4 @@
 		overflow: hidden;
 		position: relative;
 	}
-
-	.thumbnail::before {
-		content: ' ';
-		position: absolute;
-		left: 50%;
-		top: 50%;
-		height: 0;
-		float: left;
-		background: url(/assets/av-splash-65x65.png) no-repeat center top;
-		background-size: auto;
-		width: 65px;
-		padding-top: 65px;
-		margin-top: -33px;
-		margin-left: -33px;
-		background-size: 100% auto;
-	}
 </style>

--- a/src/lib/components/VideoEmbed.svelte
+++ b/src/lib/components/VideoEmbed.svelte
@@ -8,9 +8,10 @@
 
 	interface Props {
 		video: Video
+		linkToVideo?: Boolean
 	}
 
-	const { video }: Props = $props()
+	const { video, linkToVideo = false }: Props = $props()
 	let videoSource = $derived.by(() => {
 		let availableSources: Array<VideoSource> = []
 
@@ -44,11 +45,17 @@
 
 <Splash image={video.thumbnail || `${base}/assets/default.jpg`}>
 	<div class="metadata">
-		<a href={`${base}/videos/${video.show}/${video.id}`}>
+		{#if linkToVideo}
+			<a href={`${base}/videos/${video.show}/${video.id}`}>
+				<h3>{video.title}</h3>
+				<p>{video.description}</p>
+				<time datetime={video.date.toISOString()}>{video.date.toLocaleDateString()}</time>
+			</a>
+		{:else}
 			<h3>{video.title}</h3>
 			<p>{video.description}</p>
 			<time datetime={video.date.toISOString()}>{video.date.toLocaleDateString()}</time>
-		</a>
+		{/if}
 	</div>
 	<div class="video">
 		{#if videoSource == VideoSource.Direct}

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -134,7 +134,7 @@
 	{/each}
 </ul>
 
-{#if !seeAllUrl}
+{#if perPage !== -1}
 	<Pagination totalResults={videos.length} {currentPage} {totalPages} />
 {/if}
 

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -179,7 +179,7 @@
 	}
 
 	ul li:last-child {
-		background-image: none;
+		background-image: none !important;
 	}
 
 	.controls {

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -167,6 +167,10 @@
 		color: var(--color-red-active);
 	}
 
+	ul a:hover .thumbnail::before {
+		display: block;
+	}
+
 	ul li {
 		background-position: bottom;
 		background-image: url(/assets/bg-border-light.png);
@@ -228,8 +232,29 @@
 		color: var(--color-text);
 	}
 
+	.thumbnail {
+		position: relative;
+	}
+
 	.thumbnail :global(.thumbnail) {
 		box-shadow: rgba(0, 0, 0, 0.3) 0 1px 3px;
+	}
+
+	.thumbnail::before {
+		content: ' ';
+		display: none;
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		height: 0;
+		float: left;
+		background: url(/assets/av-splash-65x65.png) no-repeat center top;
+		background-size: 100% auto;
+		width: 65px;
+		padding-top: 65px;
+		margin-top: -33px;
+		margin-left: -33px;
+		z-index: 1;
 	}
 
 	@media (min-width: 576px) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,7 +39,7 @@
 	<LoadingIndicator />
 {:else}
 	{#if mainVideo}
-		<VideoEmbed video={mainVideo} linkToVideo={true} />
+		<VideoEmbed video={mainVideo} linkToVideo />
 	{/if}
 
 	<PromoStrip videos={randomVideos} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,7 +39,7 @@
 	<LoadingIndicator />
 {:else}
 	{#if mainVideo}
-		<VideoEmbed video={mainVideo} />
+		<VideoEmbed video={mainVideo} linkToVideo={true} />
 	{/if}
 
 	<PromoStrip videos={randomVideos} />

--- a/src/routes/historic/[date]/[video]/+page.svelte
+++ b/src/routes/historic/[date]/[video]/+page.svelte
@@ -67,6 +67,7 @@
 		currentVideo={data.video}
 		title="This Day in Giant Bomb History"
 		rootUri={currentUri}
+		perPage={100}
 	/>
 </section>
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -25,7 +25,7 @@
 	</form>
 
 	{#if videos.length}
-		<VideoList {videos} title={`Search results for: ${searchQuery}`} />
+		<VideoList {videos} title={`Search results for: ${searchQuery}`} perPage={100} />
 	{:else if searchQuery}
 		<div class="empty">No videos found for "{searchQuery}"</div>
 	{:else}


### PR DESCRIPTION
I did some small stylistic tweaks:

* Fixed an issue where there was a border at the bottom of the video list (when it list mode).
* Changed the logic for when the pagination (and "xyz videos" text) is shown so that it doesn't show up on the random page anymore.
* The text and description in video embed used to link to the video, but that was only really necessary for the front page so now it defaults to not being linkable.
* Hide the play icon over the video thumbnails so that it only shows up when you're hovering over the video.