### PR TITLE
Add the video duration to the video list

### DIFF
--- a/scripts/sources/GiantBomb.ts
+++ b/scripts/sources/GiantBomb.ts
@@ -36,6 +36,7 @@ export type GiantBombVideo = {
 	video_type: string
 	show: GiantBombVideoShow | null
 	youtube_id: string | null
+	duration: number | null
 }
 
 // Get the slug from a show
@@ -102,7 +103,7 @@ export default class GiantBomb {
 		const params = {
 			api_key: this.api_key,
 			format: 'json',
-			field_list: 'deck,id,guid,image,name,publish_date,video_show,video_type,youtube_id',
+			field_list: 'deck,id,guid,image,name,publish_date,video_show,video_type,youtube_id,length_seconds',
 			limit: REQUEST_LIMIT,
 			offset: 0,
 		}
@@ -143,6 +144,7 @@ export default class GiantBomb {
 					video_type: item.video_type,
 					show: show,
 					youtube_id: item.youtube_id,
+					duration: item.length_seconds ?? null,
 				} as GiantBombVideo)
 			}
 

--- a/scripts/sync_data.ts
+++ b/scripts/sync_data.ts
@@ -298,6 +298,7 @@ async function run() {
 			description: video.description,
 			date: video.publish_date,
 			thumbnail: video.image,
+			duration: video.duration,
 			source,
 		})
 
@@ -337,6 +338,7 @@ async function run() {
 			description: video.description,
 			date: video.date,
 			thumbnail: `https://archive.org/services/img/${video.identifier}`,
+			duration: null,
 			source: {
 				internetarchive: video.identifier,
 			},

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -121,6 +121,7 @@
 			<a href="{rootUri || `${base}/videos/${video.show}`}/{video.id}">
 				<div class="thumbnail">
 					<Thumbnail src={video.thumbnail || '/assets/default.jpg'} alt="" />
+					<span class="duration">{video.duration}</span>
 				</div>
 				<div class="metadata">
 					<h3>{video.title}</h3>
@@ -255,6 +256,20 @@
 		margin-top: -33px;
 		margin-left: -33px;
 		z-index: 1;
+	}
+
+	.thumbnail .duration {
+		background: black;
+		border-radius: 100px;
+		bottom: var(--spacing-less);
+		box-shadow: rgba(255, 255, 255, 0.25) 0 1px 1px;
+		color: white;
+		font-size: 12px;
+		left: var(--spacing-less);
+		line-height: 16px;
+		padding: 1px 6px 0;
+		position: absolute;
+		text-shadow: rgba(0, 0, 0, 0.5) 0 -1px 0;
 	}
 
 	@media (min-width: 576px) {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -43,6 +43,7 @@ export interface Video {
 	readonly date: Date
 	readonly show?: string
 	readonly thumbnail?: string
+	readonly duration?: number
 	readonly source: {
 		readonly internetarchive?: string
 		readonly direct?: string
@@ -119,6 +120,7 @@ export class DataStore {
 				date: new Date(video.date ?? '2008-03-06T12:00Z'),
 				show: video.show,
 				thumbnail: video.thumbnail,
+				duration: video.duration,
 				source: video.source,
 			}
 		}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -73,8 +73,8 @@ function formatDuration(duration: number | null): string {
 	}
 
 	const hours = Math.floor(duration / SECONDS_PER_HOUR)
-	const minutes = Math.floor((duration - hours * SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)
-	const seconds = duration - hours * SECONDS_PER_HOUR - minutes * SECONDS_PER_MINUTE
+	const minutes = Math.floor(duration % SECONDS_PER_HOUR / SECONDS_PER_MINUTE)
+	const seconds = duration % SECONDS_PER_MINUTE
 
 	return (
 		String(hours).padStart(2, '0') +

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -43,13 +43,16 @@ export interface Video {
 	readonly date: Date
 	readonly show?: string
 	readonly thumbnail?: string
-	readonly duration?: number
+	readonly duration: string
 	readonly source: {
 		readonly internetarchive?: string
 		readonly direct?: string
 		readonly youtube?: string
 	}
 }
+
+const SECONDS_PER_HOUR = 3600
+const SECONDS_PER_MINUTE = 60
 
 // Sort by date descending
 const byDateDesc = (a: { date: Date }, b: { date: Date }) => b.date.getTime() - a.date.getTime()
@@ -62,6 +65,25 @@ const byRandom = () => 0.5 - Math.random()
 
 // Sort by title ascending
 const byTitleAsc = (a: { title: string }, b: { title: string }) => a.title.localeCompare(b.title)
+
+// Format the duration, converting from seconds to hh:mm:ss
+function formatDuration(duration: number | null): string {
+	if (!duration) {
+		return '--:--:--'
+	}
+
+	const hours = Math.floor(duration / SECONDS_PER_HOUR)
+	const minutes = Math.floor((duration - hours * SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)
+	const seconds = duration - hours * SECONDS_PER_HOUR - minutes * SECONDS_PER_MINUTE
+
+	return (
+		String(hours).padStart(2, '0') +
+		':' +
+		String(minutes).padStart(2, '0') +
+		':' +
+		String(seconds).padStart(2, '0')
+	)
+}
 
 // Data store which contains the data for the app.
 export class DataStore {
@@ -120,7 +142,7 @@ export class DataStore {
 				date: new Date(video.date ?? '2008-03-06T12:00Z'),
 				show: video.show,
 				thumbnail: video.thumbnail,
-				duration: video.duration,
+				duration: formatDuration(video.duration),
 				source: video.source,
 			}
 		}

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -50,6 +50,7 @@ const testVideoData = [
 		description: "Let's posse up and see what's new in the world of Red Dead.",
 		date: '2020-03-02T00:00:00Z',
 		thumbnail: 'https://archive.org/services/img/gb-2300-15259-IDJIYS2',
+		duration: 7300,
 		source: {
 			internetarchive: 'gb-2300-15259-IDJIYS2',
 		},
@@ -62,6 +63,7 @@ const testVideoData = [
 			'Join us as we wish Abby well using full sentences, one word, and eventually questionable hand gestures.',
 		date: '2020-11-25T00:00:00Z',
 		thumbnail: 'https://archive.org/services/img/gb-2300-16398-IDJKE0C',
+		duration: 7925,
 		source: {
 			internetarchive: 'gb-2300-16398-IDJKE0C',
 		},
@@ -74,6 +76,7 @@ const testVideoData = [
 		date: '2009-02-11T00:00:00Z',
 		thumbnail:
 			'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+		duration: null,
 		source: {
 			internetarchive:
 				'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
@@ -88,6 +91,7 @@ const testVideoData = [
 		date: '2009-02-19T00:00:00Z',
 		thumbnail:
 			'https://archive.org/services/img/2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+		duration: null,
 		source: {
 			internetarchive:
 				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
@@ -101,6 +105,7 @@ const testVideoData = [
 		date: '2009-02-26T00:00:00Z',
 		thumbnail:
 			'https://archive.org/services/img/2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+		duration: null,
 		source: {
 			internetarchive:
 				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
@@ -160,6 +165,7 @@ describe('DataStore', () => {
 					description: "Let's posse up and see what's new in the world of Red Dead.",
 					date: new Date('2020-03-02T00:00:00Z'),
 					thumbnail: 'https://archive.org/services/img/gb-2300-15259-IDJIYS2',
+					duration: 7300,
 					show: 'cross-coast',
 					source: {
 						internetarchive: 'gb-2300-15259-IDJIYS2',
@@ -172,6 +178,7 @@ describe('DataStore', () => {
 						'Join us as we wish Abby well using full sentences, one word, and eventually questionable hand gestures.',
 					date: new Date('2020-11-25T00:00:00Z'),
 					thumbnail: 'https://archive.org/services/img/gb-2300-16398-IDJKE0C',
+					duration: 7925,
 					show: 'cross-coast',
 					source: {
 						internetarchive: 'gb-2300-16398-IDJKE0C',
@@ -185,6 +192,7 @@ describe('DataStore', () => {
 					date: new Date('2009-02-11T00:00:00Z'),
 					thumbnail:
 						'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+					duration: null,
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
@@ -199,6 +207,7 @@ describe('DataStore', () => {
 					date: new Date('2009-02-19T00:00:00Z'),
 					thumbnail:
 						'https://archive.org/services/img/2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+					duration: null,
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
@@ -212,6 +221,7 @@ describe('DataStore', () => {
 					date: new Date('2009-02-26T00:00:00Z'),
 					thumbnail:
 						'https://archive.org/services/img/2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+					duration: null,
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -76,7 +76,7 @@ const testVideoData = [
 		date: '2009-02-11T00:00:00Z',
 		thumbnail:
 			'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-		duration: null,
+		duration: 1,
 		source: {
 			internetarchive:
 				'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
@@ -165,7 +165,7 @@ describe('DataStore', () => {
 					description: "Let's posse up and see what's new in the world of Red Dead.",
 					date: new Date('2020-03-02T00:00:00Z'),
 					thumbnail: 'https://archive.org/services/img/gb-2300-15259-IDJIYS2',
-					duration: 7300,
+					duration: '02:01:40',
 					show: 'cross-coast',
 					source: {
 						internetarchive: 'gb-2300-15259-IDJIYS2',
@@ -178,7 +178,7 @@ describe('DataStore', () => {
 						'Join us as we wish Abby well using full sentences, one word, and eventually questionable hand gestures.',
 					date: new Date('2020-11-25T00:00:00Z'),
 					thumbnail: 'https://archive.org/services/img/gb-2300-16398-IDJKE0C',
-					duration: 7925,
+					duration: '02:12:05',
 					show: 'cross-coast',
 					source: {
 						internetarchive: 'gb-2300-16398-IDJKE0C',
@@ -192,7 +192,7 @@ describe('DataStore', () => {
 					date: new Date('2009-02-11T00:00:00Z'),
 					thumbnail:
 						'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-					duration: null,
+					duration: '00:00:01',
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
@@ -207,7 +207,7 @@ describe('DataStore', () => {
 					date: new Date('2009-02-19T00:00:00Z'),
 					thumbnail:
 						'https://archive.org/services/img/2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-					duration: null,
+					duration: '--:--:--',
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
@@ -221,7 +221,7 @@ describe('DataStore', () => {
 					date: new Date('2009-02-26T00:00:00Z'),
 					thumbnail:
 						'https://archive.org/services/img/2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
-					duration: null,
+					duration: '--:--:--',
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:


### PR DESCRIPTION
This shows the duration as it appeared in the 2015 site. It can only show the duration for videos available in the API, so for ones that are only from IA it shows "--:--:--" (see the Garage Talk in the image below).

<img width="1294" alt="Screenshot 2025-05-05 at 16 22 05" src="https://github.com/user-attachments/assets/714793ba-08a9-49ea-8d77-86780044a536" />
