### PR TITLE
Add video description and show title/description to the search index

### DIFF
--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -34,7 +34,7 @@
 
 	let videosReversed = $derived([...videos].reverse())
 	let sortedVideos = $derived(
-		$videoListSorting === VideoListSorting.NewestFirst ? videos : videosReversed
+		$videoListSorting === VideoListSorting.NewestFirst || !sortable ? videos : videosReversed
 	)
 
 	let totalPages = $derived(perPage != -1 ? Math.ceil(videos.length / perPage) : 1)

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -55,6 +55,10 @@ export interface Video {
 
 const SECONDS_PER_HOUR = 3600
 const SECONDS_PER_MINUTE = 60
+const SEARCH_WEIGHTS = {
+	TITLE: 10,
+	DESCRIPTION: 5,
+}
 
 // Sort by date descending
 const byDateDesc = (a: { date: Date }, b: { date: Date }) => b.date.getTime() - a.date.getTime()
@@ -153,14 +157,24 @@ export class DataStore {
 
 		this.videoIndex = new Map()
 		for (const video of videoData) {
-			const words = extractWords(video.title)
-
-			for (const word of words) {
+			for (const word of extractWords(video.title)) {
 				if (!this.videoIndex.has(word)) {
 					this.videoIndex.set(word, new Map())
 				}
 
-				this.videoIndex.get(word)!.set(video.id, 10)
+				this.videoIndex.get(word)!.set(video.id, SEARCH_WEIGHTS.TITLE)
+			}
+
+			for (const word of extractWords(video.description)) {
+				if (!this.videoIndex.has(word)) {
+					this.videoIndex.set(word, new Map())
+				}
+
+				if (this.videoIndex.get(word)!.has(video.id)) {
+					continue // use the title weight
+				}
+
+				this.videoIndex.get(word)!.set(video.id, SEARCH_WEIGHTS.DESCRIPTION)
 			}
 		}
 	}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -58,6 +58,7 @@ const SECONDS_PER_MINUTE = 60
 const SEARCH_WEIGHTS = {
 	TITLE: 10,
 	DESCRIPTION: 5,
+	SHOW: 1,
 }
 
 // Sort by date descending
@@ -156,26 +157,26 @@ export class DataStore {
 		}
 
 		this.videoIndex = new Map()
+		// Helper function for adding some text to the index with the given video ID and weight
+		const addWordToIndex = (text: string, videoId: string, weight: number) => {
+			extractWords(text).map((word) => {
+				if (!this.videoIndex.has(word)) {
+					this.videoIndex.set(word, new Map())
+				}
+
+				if (this.videoIndex.get(word)!.has(videoId)) {
+					return // use the previous weight
+				}
+
+				this.videoIndex.get(word)!.set(videoId, weight)
+			})
+		}
+
 		for (const video of videoData) {
-			for (const word of extractWords(video.title)) {
-				if (!this.videoIndex.has(word)) {
-					this.videoIndex.set(word, new Map())
-				}
-
-				this.videoIndex.get(word)!.set(video.id, SEARCH_WEIGHTS.TITLE)
-			}
-
-			for (const word of extractWords(video.description)) {
-				if (!this.videoIndex.has(word)) {
-					this.videoIndex.set(word, new Map())
-				}
-
-				if (this.videoIndex.get(word)!.has(video.id)) {
-					continue // use the title weight
-				}
-
-				this.videoIndex.get(word)!.set(video.id, SEARCH_WEIGHTS.DESCRIPTION)
-			}
+			addWordToIndex(video.title, video.id, SEARCH_WEIGHTS.TITLE)
+			addWordToIndex(video.description, video.id, SEARCH_WEIGHTS.DESCRIPTION)
+			addWordToIndex(this.shows[video.show].title, video.id, SEARCH_WEIGHTS.SHOW)
+			addWordToIndex(this.shows[video.show].description, video.id, SEARCH_WEIGHTS.SHOW)
 		}
 	}
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -75,7 +75,7 @@ function formatDuration(duration: number | null): string {
 	}
 
 	const hours = Math.floor(duration / SECONDS_PER_HOUR)
-	const minutes = Math.floor(duration % SECONDS_PER_HOUR / SECONDS_PER_MINUTE)
+	const minutes = Math.floor((duration % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)
 	const seconds = duration % SECONDS_PER_MINUTE
 
 	return (
@@ -92,7 +92,7 @@ export class DataStore {
 	readonly people: People
 	readonly shows: { [key: string]: Show }
 	readonly videos: { [key: string]: Video }
-	readonly videoIndex: Map<string, string[]>
+	readonly videoIndex: Map<string, Map<string, number>>
 
 	// Construct the datastore based on given show and video data.
 	constructor(peopleData: any, showData: any[], videoData: any[]) {
@@ -157,10 +157,10 @@ export class DataStore {
 
 			for (const word of words) {
 				if (!this.videoIndex.has(word)) {
-					this.videoIndex.set(word, [])
+					this.videoIndex.set(word, new Map())
 				}
 
-				this.videoIndex.get(word)!.push(video.id)
+				this.videoIndex.get(word)!.set(video.id, 10)
 			}
 		}
 	}
@@ -238,13 +238,14 @@ export class DataStore {
 		for (const word of words) {
 			this.videoIndex.forEach((value, key) => {
 				if (key.search(word) !== -1) {
-					const matchWeight = word == key ? 10 : 5
+					const weightMultiplier = word == key ? 2 : 1 // exact matches are worth double
 
-					this.videoIndex.get(key)!.forEach((item) => {
-						if (!foundVideos.has(item)) {
-							foundVideos.set(item, 0)
+					this.videoIndex.get(key)!.forEach((weight, id) => {
+						if (!foundVideos.has(id)) {
+							foundVideos.set(id, 0)
 						}
-						foundVideos.set(item, foundVideos.get(item) + matchWeight)
+
+						foundVideos.set(id, foundVideos.get(id) + weight * weightMultiplier)
 					})
 				}
 			})

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -13,6 +13,10 @@ export function dateToText(date: Date): string {
 
 // Extract all the significant words from a piece of text
 export function extractWords(text: string): string[] {
+	if (!text) {
+		return []
+	}
+
 	text = text.replace(ignoredCharacters, '')
 
 	const words: Set<string> = new Set()

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -25,7 +25,12 @@
 	</form>
 
 	{#if videos.length}
-		<VideoList {videos} title={`Search results for: ${searchQuery}`} perPage={100} />
+		<VideoList
+			{videos}
+			title={`Search results for: ${searchQuery}`}
+			perPage={100}
+			sortable={false}
+		/>
 	{:else if searchQuery}
 		<div class="empty">No videos found for "{searchQuery}"</div>
 	{:else}

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -69,7 +69,7 @@ const testVideoData = [
 	{
 		id: 'IDBF5DWY',
 		show: 'this-aint-no-game',
-		title: "This Ain't No Game: Double Dragon",
+		title: 'Double Dragon',
 		description: "Ryan kicks off his movie tour with this...well...it's definitely a movie.",
 		date: '2009-02-11T00:00:00Z',
 		thumbnail:
@@ -82,7 +82,7 @@ const testVideoData = [
 	{
 		id: 'IDIAQF2N',
 		show: 'this-aint-no-game',
-		title: "This Ain't No Game: Street Fighter",
+		title: 'Street Fighter',
 		description:
 			"In honor of Street Fighter IV's release, we're sharing this epic piece of cinema.",
 		date: '2009-02-19T00:00:00Z',
@@ -96,7 +96,7 @@ const testVideoData = [
 	{
 		id: 'IDB90NXY',
 		show: 'this-aint-no-game',
-		title: "This Ain't No Game: Resident Evil",
+		title: 'Resident Evil',
 		description: 'Ryan finds some love for the master of anti-dog karate.',
 		date: '2009-02-26T00:00:00Z',
 		thumbnail:
@@ -179,7 +179,7 @@ describe('DataStore', () => {
 				},
 				IDBF5DWY: {
 					id: 'IDBF5DWY',
-					title: "This Ain't No Game: Double Dragon",
+					title: 'Double Dragon',
 					description:
 						"Ryan kicks off his movie tour with this...well...it's definitely a movie.",
 					date: new Date('2009-02-11T00:00:00Z'),
@@ -193,7 +193,7 @@ describe('DataStore', () => {
 				},
 				IDIAQF2N: {
 					id: 'IDIAQF2N',
-					title: "This Ain't No Game: Street Fighter",
+					title: 'Street Fighter',
 					description:
 						"In honor of Street Fighter IV's release, we're sharing this epic piece of cinema.",
 					date: new Date('2009-02-19T00:00:00Z'),
@@ -207,7 +207,7 @@ describe('DataStore', () => {
 				},
 				IDB90NXY: {
 					id: 'IDB90NXY',
-					title: "This Ain't No Game: Resident Evil",
+					title: 'Resident Evil',
 					description: 'Ryan finds some love for the master of anti-dog karate.',
 					date: new Date('2009-02-26T00:00:00Z'),
 					thumbnail:
@@ -227,24 +227,34 @@ describe('DataStore', () => {
 			expect(dataStore.videos).toStrictEqual(expectedVideos)
 		})
 
-		it('generates a video index', () => {
+		it('generates a video search index', () => {
 			const expected = new Map(
 				Object.entries({
 					'2': new Map(Object.entries({ '2300-15259': 10 })),
 					a: new Map(Object.entries({ IDBF5DWY: 5 })),
 					abby: new Map(Object.entries({ '2300-16398': 5 })),
 					abbys: new Map(Object.entries({ '2300-16398': 10 })),
+					across: new Map(Object.entries({ '2300-15259': 1, '2300-16398': 1 })),
 					aint: new Map(
 						Object.entries({
-							IDBF5DWY: 10,
-							IDIAQF2N: 10,
-							IDB90NXY: 10,
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
+					all: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 1,
 						})
 					),
 					and: new Map(
 						Object.entries({
 							'2300-15259': 5,
 							'2300-16398': 5,
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
 						})
 					),
 					anti: new Map(Object.entries({ IDB90NXY: 5 })),
@@ -252,6 +262,12 @@ describe('DataStore', () => {
 					but: new Map(Object.entries({ '2300-16398': 10 })),
 					cinema: new Map(Object.entries({ IDIAQF2N: 5 })),
 					coast: new Map(Object.entries({ '2300-15259': 10, '2300-16398': 10 })),
+					country: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 1,
+						})
+					),
 					cross: new Map(Object.entries({ '2300-15259': 10, '2300-16398': 10 })),
 					dead: new Map(Object.entries({ '2300-15259': 10 })),
 					definitely: new Map(Object.entries({ IDBF5DWY: 5 })),
@@ -276,12 +292,18 @@ describe('DataStore', () => {
 					),
 					finds: new Map(Object.entries({ IDB90NXY: 5 })),
 					for: new Map(Object.entries({ IDB90NXY: 5 })),
+					forces: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 1,
+						})
+					),
 					full: new Map(Object.entries({ '2300-16398': 5 })),
 					game: new Map(
 						Object.entries({
-							IDBF5DWY: 10,
-							IDIAQF2N: 10,
-							IDB90NXY: 10,
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
 						})
 					),
 					gestures: new Map(Object.entries({ '2300-16398': 5 })),
@@ -290,28 +312,73 @@ describe('DataStore', () => {
 					his: new Map(Object.entries({ IDBF5DWY: 5 })),
 					honor: new Map(Object.entries({ IDIAQF2N: 5 })),
 					in: new Map(Object.entries({ '2300-15259': 5, IDIAQF2N: 5 })),
+					into: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					its: new Map(Object.entries({ IDBF5DWY: 5 })),
 					ivs: new Map(Object.entries({ IDIAQF2N: 5 })),
-					join: new Map(Object.entries({ '2300-16398': 5 })),
+					join: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 5,
+						})
+					),
 					karate: new Map(Object.entries({ IDB90NXY: 5 })),
 					kicks: new Map(Object.entries({ IDBF5DWY: 5 })),
 					later: new Map(Object.entries({ '2300-16398': 10 })),
 					lets: new Map(Object.entries({ '2300-15259': 5 })),
+					look: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					love: new Map(Object.entries({ IDB90NXY: 5 })),
 					master: new Map(Object.entries({ IDB90NXY: 5 })),
 					movie: new Map(Object.entries({ IDBF5DWY: 5 })),
+					movies: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					new: new Map(Object.entries({ '2300-15259': 5 })),
 					no: new Map(
 						Object.entries({
-							IDBF5DWY: 10,
-							IDIAQF2N: 10,
-							IDB90NXY: 10,
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
 						})
 					),
 					not: new Map(Object.entries({ '2300-16398': 10 })),
-					of: new Map(Object.entries({ '2300-15259': 5, IDIAQF2N: 5, IDB90NXY: 5 })),
+					obstacles: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 1,
+						})
+					),
+					of: new Map(
+						Object.entries({
+							'2300-15259': 5,
+							IDBF5DWY: 1,
+							IDIAQF2N: 5,
+							IDB90NXY: 5,
+						})
+					),
 					off: new Map(Object.entries({ IDBF5DWY: 5 })),
 					one: new Map(Object.entries({ '2300-16398': 5 })),
+					overcome: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 1,
+						})
+					),
 					piece: new Map(Object.entries({ IDIAQF2N: 5 })),
 					posse: new Map(Object.entries({ '2300-15259': 5 })),
 					questionable: new Map(Object.entries({ '2300-16398': 5 })),
@@ -339,27 +406,89 @@ describe('DataStore', () => {
 							IDIAQF2N: 10,
 						})
 					),
-					the: new Map(Object.entries({ '2300-15259': 5, IDB90NXY: 5 })),
+					the: new Map(
+						Object.entries({
+							'2300-15259': 5,
+							'2300-16398': 1,
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 5,
+						})
+					),
+					themes: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					this: new Map(
 						Object.entries({
-							IDBF5DWY: 10,
-							IDIAQF2N: 10,
-							IDB90NXY: 10,
+							IDBF5DWY: 5,
+							IDIAQF2N: 5,
+							IDB90NXY: 1,
+						})
+					),
+					to: new Map(
+						Object.entries({
+							'2300-15259': 1,
+							'2300-16398': 1,
 						})
 					),
 					tour: new Map(Object.entries({ IDBF5DWY: 5 })),
+					universe: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					up: new Map(Object.entries({ '2300-15259': 5 })),
 					us: new Map(Object.entries({ '2300-16398': 5 })),
 					using: new Map(Object.entries({ '2300-16398': 5 })),
-					we: new Map(Object.entries({ '2300-16398': 5 })),
+					video: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
+					we: new Map(Object.entries({ '2300-15259': 1, '2300-16398': 5 })),
 					well: new Map(Object.entries({ '2300-16398': 5, IDBF5DWY: 5 })),
 					were: new Map(Object.entries({ IDIAQF2N: 5 })),
 					whats: new Map(Object.entries({ '2300-15259': 5 })),
 					wish: new Map(Object.entries({ '2300-16398': 5 })),
-					with: new Map(Object.entries({ IDBF5DWY: 5 })),
+					with: new Map(
+						Object.entries({
+							IDBF5DWY: 5,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
+					wonderful: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					word: new Map(Object.entries({ '2300-16398': 5 })),
-					world: new Map(Object.entries({ '2300-15259': 5 })),
+					world: new Map(
+						Object.entries({
+							'2300-15259': 5,
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 					you: new Map(Object.entries({ '2300-16398': 10 })),
+					your: new Map(
+						Object.entries({
+							IDBF5DWY: 1,
+							IDIAQF2N: 1,
+							IDB90NXY: 1,
+						})
+					),
 				})
 			)
 

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -29,11 +29,7 @@ const testShowData = [
 			'Your look into the world of video game movies and the Wonderful Universe of movies with video game themes.',
 		poster: '3026329-gb_default-16_9.jpg',
 		logo: null,
-		videos: [
-			'IDBF5DWY',
-			'IDIAQF2N',
-			'IDB90NXY',
-		],
+		videos: ['IDBF5DWY', 'IDIAQF2N', 'IDB90NXY'],
 	},
 	{
 		id: 'cross-coast',
@@ -80,8 +76,7 @@ const testVideoData = [
 			'https://archive.org/services/img/2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
 		duration: 1,
 		source: {
-			internetarchive:
-				'IDBF5DWY',
+			internetarchive: 'IDBF5DWY',
 		},
 	},
 	{
@@ -95,8 +90,7 @@ const testVideoData = [
 			'https://archive.org/services/img/2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
 		duration: null,
 		source: {
-			internetarchive:
-				'IDIAQF2N',
+			internetarchive: 'IDIAQF2N',
 		},
 	},
 	{
@@ -109,8 +103,7 @@ const testVideoData = [
 			'https://archive.org/services/img/2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
 		duration: null,
 		source: {
-			internetarchive:
-				'IDB90NXY',
+			internetarchive: 'IDB90NXY',
 		},
 	},
 ]
@@ -155,11 +148,7 @@ describe('DataStore', () => {
 						'Your look into the world of video game movies and the Wonderful Universe of movies with video game themes.',
 					poster: '3026329-gb_default-16_9.jpg',
 					logo: null,
-					videos: [
-						'IDBF5DWY',
-						'IDIAQF2N',
-						'IDB90NXY',
-					],
+					videos: ['IDBF5DWY', 'IDIAQF2N', 'IDB90NXY'],
 				},
 			}
 			const expectedVideos = {
@@ -188,7 +177,7 @@ describe('DataStore', () => {
 						internetarchive: 'gb-2300-16398-IDJKE0C',
 					},
 				},
-				'IDBF5DWY': {
+				IDBF5DWY: {
 					id: 'IDBF5DWY',
 					title: "This Ain't No Game: Double Dragon",
 					description:
@@ -199,11 +188,10 @@ describe('DataStore', () => {
 					duration: '00:00:01',
 					show: 'this-aint-no-game',
 					source: {
-						internetarchive:
-							'IDBF5DWY',
+						internetarchive: 'IDBF5DWY',
 					},
 				},
-				'IDIAQF2N': {
+				IDIAQF2N: {
 					id: 'IDIAQF2N',
 					title: "This Ain't No Game: Street Fighter",
 					description:
@@ -214,11 +202,10 @@ describe('DataStore', () => {
 					duration: '--:--:--',
 					show: 'this-aint-no-game',
 					source: {
-						internetarchive:
-							'IDIAQF2N',
+						internetarchive: 'IDIAQF2N',
 					},
 				},
-				'IDB90NXY': {
+				IDB90NXY: {
 					id: 'IDB90NXY',
 					title: "This Ain't No Game: Resident Evil",
 					description: 'Ryan finds some love for the master of anti-dog karate.',
@@ -228,8 +215,7 @@ describe('DataStore', () => {
 					duration: '--:--:--',
 					show: 'this-aint-no-game',
 					source: {
-						internetarchive:
-							'IDB90NXY',
+						internetarchive: 'IDB90NXY',
 					},
 				},
 			}
@@ -244,56 +230,74 @@ describe('DataStore', () => {
 		it('generates a video index', () => {
 			const expected = new Map(
 				Object.entries({
-					'2': ['2300-15259'],
-					abbys: ['2300-16398'],
-					aint: [
-						'IDBF5DWY',
-						'IDIAQF2N',
-						'IDB90NXY',
-					],
-					but: ['2300-16398'],
-					coast: ['2300-15259', '2300-16398'],
-					cross: ['2300-15259', '2300-16398'],
-					dead: ['2300-15259'],
-					double: [
-						'IDBF5DWY',
-					],
-					dragon: [
-						'IDBF5DWY',
-					],
-					evil: ['IDB90NXY'],
-					fighter: [
-						'IDIAQF2N',
-					],
-					game: [
-						'IDBF5DWY',
-						'IDIAQF2N',
-						'IDB90NXY',
-					],
-					goodbye: ['2300-16398'],
-					later: ['2300-16398'],
-					no: [
-						'IDBF5DWY',
-						'IDIAQF2N',
-						'IDB90NXY',
-					],
-					not: ['2300-16398'],
-					red: ['2300-15259'],
-					redemption: ['2300-15259'],
-					resident: [
-						'IDB90NXY',
-					],
-					see: ['2300-16398'],
-					stream: ['2300-16398'],
-					street: [
-						'IDIAQF2N',
-					],
-					this: [
-						'IDBF5DWY',
-						'IDIAQF2N',
-						'IDB90NXY',
-					],
-					you: ['2300-16398'],
+					'2': new Map(Object.entries({ '2300-15259': 10 })),
+					abbys: new Map(Object.entries({ '2300-16398': 10 })),
+					aint: new Map(
+						Object.entries({
+							IDBF5DWY: 10,
+							IDIAQF2N: 10,
+							IDB90NXY: 10,
+						})
+					),
+					but: new Map(Object.entries({ '2300-16398': 10 })),
+					coast: new Map(Object.entries({ '2300-15259': 10, '2300-16398': 10 })),
+					cross: new Map(Object.entries({ '2300-15259': 10, '2300-16398': 10 })),
+					dead: new Map(Object.entries({ '2300-15259': 10 })),
+					double: new Map(
+						Object.entries({
+							IDBF5DWY: 10,
+						})
+					),
+					dragon: new Map(
+						Object.entries({
+							IDBF5DWY: 10,
+						})
+					),
+					evil: new Map(Object.entries({ IDB90NXY: 10 })),
+					fighter: new Map(
+						Object.entries({
+							IDIAQF2N: 10,
+						})
+					),
+					game: new Map(
+						Object.entries({
+							IDBF5DWY: 10,
+							IDIAQF2N: 10,
+							IDB90NXY: 10,
+						})
+					),
+					goodbye: new Map(Object.entries({ '2300-16398': 10 })),
+					later: new Map(Object.entries({ '2300-16398': 10 })),
+					no: new Map(
+						Object.entries({
+							IDBF5DWY: 10,
+							IDIAQF2N: 10,
+							IDB90NXY: 10,
+						})
+					),
+					not: new Map(Object.entries({ '2300-16398': 10 })),
+					red: new Map(Object.entries({ '2300-15259': 10 })),
+					redemption: new Map(Object.entries({ '2300-15259': 10 })),
+					resident: new Map(
+						Object.entries({
+							IDB90NXY: 10,
+						})
+					),
+					see: new Map(Object.entries({ '2300-16398': 10 })),
+					stream: new Map(Object.entries({ '2300-16398': 10 })),
+					street: new Map(
+						Object.entries({
+							IDIAQF2N: 10,
+						})
+					),
+					this: new Map(
+						Object.entries({
+							IDBF5DWY: 10,
+							IDIAQF2N: 10,
+							IDB90NXY: 10,
+						})
+					),
+					you: new Map(Object.entries({ '2300-16398': 10 })),
 				})
 			)
 
@@ -360,15 +364,9 @@ describe('DataStore', () => {
 	describe('getVideoById', () => {
 		it('gets a specific video', () => {
 			const dataStore = new DataStore(testPeopleData, testShowData, testVideoData)
-			const result = dataStore.getVideoById(
-				'IDIAQF2N'
-			)
+			const result = dataStore.getVideoById('IDIAQF2N')
 
-			expect(result).toStrictEqual(
-				dataStore.videos[
-					'IDIAQF2N'
-				]
-			)
+			expect(result).toStrictEqual(dataStore.videos['IDIAQF2N'])
 		})
 	})
 
@@ -410,9 +408,7 @@ describe('DataStore', () => {
 			const dataStore = new DataStore(testPeopleData, testShowData, testVideoData)
 			const result = dataStore.searchVideos('evil')
 
-			expect(result.map((x) => x.id)).toStrictEqual([
-				'IDB90NXY',
-			])
+			expect(result.map((x) => x.id)).toStrictEqual(['IDB90NXY'])
 		})
 
 		it('weighs exact matches higher than non-exact ones', () => {

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -30,9 +30,9 @@ const testShowData = [
 		poster: '3026329-gb_default-16_9.jpg',
 		logo: null,
 		videos: [
-			'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-			'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-			'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+			'IDBF5DWY',
+			'IDIAQF2N',
+			'IDB90NXY',
 		],
 	},
 	{
@@ -71,7 +71,7 @@ const testVideoData = [
 		},
 	},
 	{
-		id: '2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+		id: 'IDBF5DWY',
 		show: 'this-aint-no-game',
 		title: "This Ain't No Game: Double Dragon",
 		description: "Ryan kicks off his movie tour with this...well...it's definitely a movie.",
@@ -81,11 +81,11 @@ const testVideoData = [
 		duration: 1,
 		source: {
 			internetarchive:
-				'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+				'IDBF5DWY',
 		},
 	},
 	{
-		id: '2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+		id: 'IDIAQF2N',
 		show: 'this-aint-no-game',
 		title: "This Ain't No Game: Street Fighter",
 		description:
@@ -96,11 +96,11 @@ const testVideoData = [
 		duration: null,
 		source: {
 			internetarchive:
-				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+				'IDIAQF2N',
 		},
 	},
 	{
-		id: '2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+		id: 'IDB90NXY',
 		show: 'this-aint-no-game',
 		title: "This Ain't No Game: Resident Evil",
 		description: 'Ryan finds some love for the master of anti-dog karate.',
@@ -110,7 +110,7 @@ const testVideoData = [
 		duration: null,
 		source: {
 			internetarchive:
-				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+				'IDB90NXY',
 		},
 	},
 ]
@@ -156,9 +156,9 @@ describe('DataStore', () => {
 					poster: '3026329-gb_default-16_9.jpg',
 					logo: null,
 					videos: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'IDBF5DWY',
+						'IDIAQF2N',
+						'IDB90NXY',
 					],
 				},
 			}
@@ -188,8 +188,8 @@ describe('DataStore', () => {
 						internetarchive: 'gb-2300-16398-IDJKE0C',
 					},
 				},
-				'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY': {
-					id: '2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+				'IDBF5DWY': {
+					id: 'IDBF5DWY',
 					title: "This Ain't No Game: Double Dragon",
 					description:
 						"Ryan kicks off his movie tour with this...well...it's definitely a movie.",
@@ -200,11 +200,11 @@ describe('DataStore', () => {
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
-							'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+							'IDBF5DWY',
 					},
 				},
-				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N': {
-					id: '2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+				'IDIAQF2N': {
+					id: 'IDIAQF2N',
 					title: "This Ain't No Game: Street Fighter",
 					description:
 						"In honor of Street Fighter IV's release, we're sharing this epic piece of cinema.",
@@ -215,11 +215,11 @@ describe('DataStore', () => {
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
-							'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+							'IDIAQF2N',
 					},
 				},
-				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY': {
-					id: '2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+				'IDB90NXY': {
+					id: 'IDB90NXY',
 					title: "This Ain't No Game: Resident Evil",
 					description: 'Ryan finds some love for the master of anti-dog karate.',
 					date: new Date('2009-02-26T00:00:00Z'),
@@ -229,7 +229,7 @@ describe('DataStore', () => {
 					show: 'this-aint-no-game',
 					source: {
 						internetarchive:
-							'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+							'IDB90NXY',
 					},
 				},
 			}
@@ -247,51 +247,51 @@ describe('DataStore', () => {
 					'2': ['2300-15259'],
 					abbys: ['2300-16398'],
 					aint: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'IDBF5DWY',
+						'IDIAQF2N',
+						'IDB90NXY',
 					],
 					but: ['2300-16398'],
 					coast: ['2300-15259', '2300-16398'],
 					cross: ['2300-15259', '2300-16398'],
 					dead: ['2300-15259'],
 					double: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+						'IDBF5DWY',
 					],
 					dragon: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+						'IDBF5DWY',
 					],
-					evil: ['2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY'],
+					evil: ['IDB90NXY'],
 					fighter: [
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+						'IDIAQF2N',
 					],
 					game: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'IDBF5DWY',
+						'IDIAQF2N',
+						'IDB90NXY',
 					],
 					goodbye: ['2300-16398'],
 					later: ['2300-16398'],
 					no: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'IDBF5DWY',
+						'IDIAQF2N',
+						'IDB90NXY',
 					],
 					not: ['2300-16398'],
 					red: ['2300-15259'],
 					redemption: ['2300-15259'],
 					resident: [
-						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'IDB90NXY',
 					],
 					see: ['2300-16398'],
 					stream: ['2300-16398'],
 					street: [
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
+						'IDIAQF2N',
 					],
 					this: [
-						'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
-						'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-						'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+						'IDBF5DWY',
+						'IDIAQF2N',
+						'IDB90NXY',
 					],
 					you: ['2300-16398'],
 				})
@@ -361,12 +361,12 @@ describe('DataStore', () => {
 		it('gets a specific video', () => {
 			const dataStore = new DataStore(testPeopleData, testShowData, testVideoData)
 			const result = dataStore.getVideoById(
-				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N'
+				'IDIAQF2N'
 			)
 
 			expect(result).toStrictEqual(
 				dataStore.videos[
-					'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N'
+					'IDIAQF2N'
 				]
 			)
 		})
@@ -389,9 +389,9 @@ describe('DataStore', () => {
 			expect(result.map((x) => x.id)).toStrictEqual([
 				'2300-16398',
 				'2300-15259',
-				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
-				'2009-02-19-This_Aint_No_Game-This_Aint_No_Game_Street_Fighter-IDIAQF2N',
-				'2009-02-11-This_Aint_No_Game-This_Aint_No_Game_Double_Dragon-IDBF5DWY',
+				'IDB90NXY',
+				'IDIAQF2N',
+				'IDBF5DWY',
 			])
 		})
 	})
@@ -411,7 +411,7 @@ describe('DataStore', () => {
 			const result = dataStore.searchVideos('evil')
 
 			expect(result.map((x) => x.id)).toStrictEqual([
-				'2009-02-26-This_Aint_No_Game-This_Aint_No_Game_Resident_Evil-IDB90NXY',
+				'IDB90NXY',
 			])
 		})
 

--- a/tests/lib/data.test.ts
+++ b/tests/lib/data.test.ts
@@ -231,6 +231,8 @@ describe('DataStore', () => {
 			const expected = new Map(
 				Object.entries({
 					'2': new Map(Object.entries({ '2300-15259': 10 })),
+					a: new Map(Object.entries({ IDBF5DWY: 5 })),
+					abby: new Map(Object.entries({ '2300-16398': 5 })),
 					abbys: new Map(Object.entries({ '2300-16398': 10 })),
 					aint: new Map(
 						Object.entries({
@@ -239,10 +241,21 @@ describe('DataStore', () => {
 							IDB90NXY: 10,
 						})
 					),
+					and: new Map(
+						Object.entries({
+							'2300-15259': 5,
+							'2300-16398': 5,
+						})
+					),
+					anti: new Map(Object.entries({ IDB90NXY: 5 })),
+					as: new Map(Object.entries({ '2300-16398': 5 })),
 					but: new Map(Object.entries({ '2300-16398': 10 })),
+					cinema: new Map(Object.entries({ IDIAQF2N: 5 })),
 					coast: new Map(Object.entries({ '2300-15259': 10, '2300-16398': 10 })),
 					cross: new Map(Object.entries({ '2300-15259': 10, '2300-16398': 10 })),
 					dead: new Map(Object.entries({ '2300-15259': 10 })),
+					definitely: new Map(Object.entries({ IDBF5DWY: 5 })),
+					dog: new Map(Object.entries({ IDB90NXY: 5 })),
 					double: new Map(
 						Object.entries({
 							IDBF5DWY: 10,
@@ -253,12 +266,17 @@ describe('DataStore', () => {
 							IDBF5DWY: 10,
 						})
 					),
+					epic: new Map(Object.entries({ IDIAQF2N: 5 })),
+					eventually: new Map(Object.entries({ '2300-16398': 5 })),
 					evil: new Map(Object.entries({ IDB90NXY: 10 })),
 					fighter: new Map(
 						Object.entries({
 							IDIAQF2N: 10,
 						})
 					),
+					finds: new Map(Object.entries({ IDB90NXY: 5 })),
+					for: new Map(Object.entries({ IDB90NXY: 5 })),
+					full: new Map(Object.entries({ '2300-16398': 5 })),
 					game: new Map(
 						Object.entries({
 							IDBF5DWY: 10,
@@ -266,8 +284,23 @@ describe('DataStore', () => {
 							IDB90NXY: 10,
 						})
 					),
+					gestures: new Map(Object.entries({ '2300-16398': 5 })),
 					goodbye: new Map(Object.entries({ '2300-16398': 10 })),
+					hand: new Map(Object.entries({ '2300-16398': 5 })),
+					his: new Map(Object.entries({ IDBF5DWY: 5 })),
+					honor: new Map(Object.entries({ IDIAQF2N: 5 })),
+					in: new Map(Object.entries({ '2300-15259': 5, IDIAQF2N: 5 })),
+					its: new Map(Object.entries({ IDBF5DWY: 5 })),
+					ivs: new Map(Object.entries({ IDIAQF2N: 5 })),
+					join: new Map(Object.entries({ '2300-16398': 5 })),
+					karate: new Map(Object.entries({ IDB90NXY: 5 })),
+					kicks: new Map(Object.entries({ IDBF5DWY: 5 })),
 					later: new Map(Object.entries({ '2300-16398': 10 })),
+					lets: new Map(Object.entries({ '2300-15259': 5 })),
+					love: new Map(Object.entries({ IDB90NXY: 5 })),
+					master: new Map(Object.entries({ IDB90NXY: 5 })),
+					movie: new Map(Object.entries({ IDBF5DWY: 5 })),
+					new: new Map(Object.entries({ '2300-15259': 5 })),
 					no: new Map(
 						Object.entries({
 							IDBF5DWY: 10,
@@ -276,20 +309,37 @@ describe('DataStore', () => {
 						})
 					),
 					not: new Map(Object.entries({ '2300-16398': 10 })),
+					of: new Map(Object.entries({ '2300-15259': 5, IDIAQF2N: 5, IDB90NXY: 5 })),
+					off: new Map(Object.entries({ IDBF5DWY: 5 })),
+					one: new Map(Object.entries({ '2300-16398': 5 })),
+					piece: new Map(Object.entries({ IDIAQF2N: 5 })),
+					posse: new Map(Object.entries({ '2300-15259': 5 })),
+					questionable: new Map(Object.entries({ '2300-16398': 5 })),
 					red: new Map(Object.entries({ '2300-15259': 10 })),
 					redemption: new Map(Object.entries({ '2300-15259': 10 })),
+					release: new Map(Object.entries({ IDIAQF2N: 5 })),
 					resident: new Map(
 						Object.entries({
 							IDB90NXY: 10,
 						})
 					),
-					see: new Map(Object.entries({ '2300-16398': 10 })),
+					ryan: new Map(
+						Object.entries({
+							IDBF5DWY: 5,
+							IDB90NXY: 5,
+						})
+					),
+					see: new Map(Object.entries({ '2300-15259': 5, '2300-16398': 10 })),
 					stream: new Map(Object.entries({ '2300-16398': 10 })),
+					sentences: new Map(Object.entries({ '2300-16398': 5 })),
+					sharing: new Map(Object.entries({ IDIAQF2N: 5 })),
+					some: new Map(Object.entries({ IDB90NXY: 5 })),
 					street: new Map(
 						Object.entries({
 							IDIAQF2N: 10,
 						})
 					),
+					the: new Map(Object.entries({ '2300-15259': 5, IDB90NXY: 5 })),
 					this: new Map(
 						Object.entries({
 							IDBF5DWY: 10,
@@ -297,6 +347,18 @@ describe('DataStore', () => {
 							IDB90NXY: 10,
 						})
 					),
+					tour: new Map(Object.entries({ IDBF5DWY: 5 })),
+					up: new Map(Object.entries({ '2300-15259': 5 })),
+					us: new Map(Object.entries({ '2300-16398': 5 })),
+					using: new Map(Object.entries({ '2300-16398': 5 })),
+					we: new Map(Object.entries({ '2300-16398': 5 })),
+					well: new Map(Object.entries({ '2300-16398': 5, IDBF5DWY: 5 })),
+					were: new Map(Object.entries({ IDIAQF2N: 5 })),
+					whats: new Map(Object.entries({ '2300-15259': 5 })),
+					wish: new Map(Object.entries({ '2300-16398': 5 })),
+					with: new Map(Object.entries({ IDBF5DWY: 5 })),
+					word: new Map(Object.entries({ '2300-16398': 5 })),
+					world: new Map(Object.entries({ '2300-15259': 5 })),
 					you: new Map(Object.entries({ '2300-16398': 10 })),
 				})
 			)


### PR DESCRIPTION
It's now possible to search for videos where the words you're searching for are in the video description, or in the title or description of the associated show.

One drawback was that I had to disable the sorting on the search page because the search results are sorted by weight, not chronologically.

![Screenshot 2025-05-09 at 21-18-38 Search - Duders Zone](https://github.com/user-attachments/assets/fa419ed6-01ea-4108-9e0d-865872d8ffb5)

This change resolves #67 
