### PR TITLE
Change duders page to grid layout

### DIFF
--- a/scripts/sources/GiantBomb.ts
+++ b/scripts/sources/GiantBomb.ts
@@ -103,7 +103,8 @@ export default class GiantBomb {
 		const params = {
 			api_key: this.api_key,
 			format: 'json',
-			field_list: 'deck,id,guid,image,name,publish_date,video_show,video_type,youtube_id,length_seconds',
+			field_list:
+				'deck,id,guid,image,name,publish_date,video_show,video_type,youtube_id,length_seconds',
 			limit: REQUEST_LIMIT,
 			offset: 0,
 		}

--- a/src/routes/people/+page.svelte
+++ b/src/routes/people/+page.svelte
@@ -164,7 +164,6 @@
 
 	ul.links {
 		font-size: 11pt;
-		min-width: 0;
 	}
 
 	ul.links li {

--- a/src/routes/people/+page.svelte
+++ b/src/routes/people/+page.svelte
@@ -164,6 +164,7 @@
 
 	ul.links {
 		font-size: 11pt;
+		min-width: 0;
 	}
 
 	ul.links li {
@@ -171,12 +172,12 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		color: var(--color-text-muted);
 	}
 
 	ul.people {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: 1fr;
 		gap: 2em;
 		margin: 2em 0;
 		justify-content: flex-start;
@@ -186,13 +187,15 @@
 		border-radius: 4px;
 	}
 
-	ul.people li {
+	ul.people > li {
 		display: flex;
 		flex: 0 0 100%;
+		min-width: 0;
 	}
 
 	ul.people .info {
 		flex: 1;
+		min-width: 0;
 		padding: 0.25em 0.85em;
 	}
 
@@ -202,14 +205,7 @@
 
 	@media (min-width: 768px) {
 		ul.people {
-			display: flex;
-			flex-direction: row;
-			flex-wrap: wrap;
-			justify-items: center;
-		}
-
-		ul.people li {
-			flex-basis: calc(50% - 1em);
+			grid-template-columns: repeat(2, 1fr);
 		}
 
 		ul.people .image {
@@ -218,8 +214,8 @@
 	}
 
 	@media (min-width: 1200px) {
-		ul.people li {
-			flex-basis: calc(34% - 2em);
+		ul.people {
+			grid-template-columns: repeat(3, 1fr);
 		}
 	}
 </style>


### PR DESCRIPTION
Reported by GarlicRagu in the Discord, some profiles were too wide and it broke the layout.

![image](https://github.com/user-attachments/assets/afe13231-db43-4f56-987c-f106950c379f)

I changed the list to use CSS grid, and made some other tweaks like fixing the text overflow ellipses for the longer social handles.

![image](https://github.com/user-attachments/assets/2c61c849-2bf0-47d3-9af7-2886f2886590)
