### PR TITLE
Show sort buttons & local storage overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"prettier-plugin-svelte": "^3.3.3",
 				"svelte": "^5.28.2",
 				"svelte-check": "^4.1.6",
+				"svelte-persisted-store": "^0.12.0",
 				"tslib": "^2.8.1",
 				"tsx": "^4.19.3",
 				"typescript": "^5.8.3",
@@ -1540,6 +1541,18 @@
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/svelte-persisted-store": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/svelte-persisted-store/-/svelte-persisted-store-0.12.0.tgz",
+			"integrity": "sha512-BdBQr2SGSJ+rDWH8/aEV5GthBJDapVP0GP3fuUCA7TjYG5ctcB+O9Mj9ZC0+Jo1oJMfZUd1y9H68NFRR5MyIJA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.14"
+			},
+			"peerDependencies": {
+				"svelte": "^3.48.0 || ^4 || ^5"
 			}
 		},
 		"node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"prettier-plugin-svelte": "^3.3.3",
 		"svelte": "^5.28.2",
 		"svelte-check": "^4.1.6",
+		"svelte-persisted-store": "^0.12.0",
 		"tslib": "^2.8.1",
 		"tsx": "^4.19.3",
 		"typescript": "^5.8.3",

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -13,7 +13,7 @@
 		OldestFirst,
 		RSS,
 		LeastFirst,
-		MostFirst
+		MostFirst,
 	}
 </script>
 
@@ -101,15 +101,11 @@
 	</svg>
 {:else if type == IconType.LeastFirst}
 	<svg viewBox="0 0 14 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-		<path
-			d="M1,9 h11 v1.5 h-11Z M1,5.25 h8 v1.5 h-8Z M1,1.5 h5 v1.5 h-5Z"
-		/>
+		<path d="M1,9 h11 v1.5 h-11Z M1,5.25 h8 v1.5 h-8Z M1,1.5 h5 v1.5 h-5Z" />
 	</svg>
 {:else if type == IconType.MostFirst}
 	<svg viewBox="0 0 14 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-		<path
-			d="M1,1.5 h11 v1.5 h-11Z M1,5.25 h8 v1.5 h-8Z M1,9 h5 v1.5 h-5"
-		/>
+		<path d="M1,1.5 h11 v1.5 h-11Z M1,5.25 h8 v1.5 h-8Z M1,9 h5 v1.5 h-5" />
 	</svg>
 {:else}
 	??

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -12,6 +12,8 @@
 		NewestFirst,
 		OldestFirst,
 		RSS,
+		LeastFirst,
+		MostFirst
 	}
 </script>
 
@@ -95,6 +97,18 @@
 	<svg viewBox="-4 -4 78 78" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
 		<path
 			d="M0,61 A9,9 0 0 0 18,61 A9,9 0 0 0 0,61 M0,38 A32,32 0 0 1 32,70 H46 A46,46 0 0 0 0,24 M0,14 A56,56 0 0 1 56,70 H70 A70,70 0 0 0 0,0"
+		/>
+	</svg>
+{:else if type == IconType.LeastFirst}
+	<svg viewBox="0 0 14 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M1,9 h11 v1.5 h-11Z M1,5.25 h8 v1.5 h-8Z M1,1.5 h5 v1.5 h-5Z"
+		/>
+	</svg>
+{:else if type == IconType.MostFirst}
+	<svg viewBox="0 0 14 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M1,1.5 h11 v1.5 h-11Z M1,5.25 h8 v1.5 h-8Z M1,9 h5 v1.5 h-5"
 		/>
 	</svg>
 {:else}

--- a/src/lib/components/ListButtons.svelte
+++ b/src/lib/components/ListButtons.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import Icon, { IconType } from './Icon.svelte'
+
+	interface Props<T = any> {
+		value: T
+		options: { label: string; option: T; icon: IconType }[]
+		onChange: (option: T) => void
+	}
+
+	const { value, options, onChange }: Props = $props()
+</script>
+
+{#each options as { label, option, icon }}
+	<button class:active={value === option} onclick={() => onChange(option)}>
+		<Icon type={icon} />
+		{label}
+	</button>
+{/each}
+
+<style>
+	button {
+		background: none;
+		border: none;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		font-family: inherit;
+		font-size: 14px;
+		line-height: 20px;
+	}
+
+	button:hover {
+		color: var(--color-red-active);
+	}
+
+	button.active {
+		color: var(--color-text);
+	}
+</style>

--- a/src/lib/components/ListButtons.svelte
+++ b/src/lib/components/ListButtons.svelte
@@ -1,7 +1,7 @@
-<script lang="ts">
+<script lang="ts" generics="T">
 	import Icon, { IconType } from './Icon.svelte'
 
-	interface Props<T = any> {
+	interface Props {
 		value: T
 		options: { label: string; option: T; icon: IconType }[]
 		onChange: (option: T) => void

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -17,6 +17,7 @@
 <label class="switch" class:dark={darkMode}>
 	<input type="checkbox" bind:checked={darkMode} />
 	<span class="modes"></span>
+	<span class="sr-only">Dark mode</span>
 </label>
 
 <style>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -3,7 +3,7 @@
 	import { theme } from '$lib/store'
 	import { Theme } from '$lib/types'
 
-	let darkMode = $state($theme === Theme.Dark)
+	let darkMode = $derived($theme === Theme.Dark)
 
 	$effect(() => {
 		const themeType = darkMode ? Theme.Dark : Theme.Light

--- a/src/lib/components/VideoEmbed.svelte
+++ b/src/lib/components/VideoEmbed.svelte
@@ -6,7 +6,7 @@
 	import LoadingIndicator from '$lib/components/LoadingIndicator.svelte'
 	import Splash from '$lib/components/Splash.svelte'
 	import { VideoSource } from '$lib/data'
-	import { preferredSource, wideVideo } from '$lib/store.js'
+	import { preferredSource, wideVideo } from '$lib/store'
 	import type { Video } from '$lib/data'
 	import type { OnNavigate } from '@sveltejs/kit'
 

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -6,7 +6,8 @@
 	import Pagination from '$lib/components/Pagination.svelte'
 	import Thumbnail from '$lib/components/Thumbnail.svelte'
 	import { videoListMode, videoListSorting } from '$lib/store'
-	import Icon, { IconType } from './Icon.svelte'
+	import ListButtons from './ListButtons.svelte'
+	import { IconType } from './Icon.svelte'
 
 	interface Props {
 		videos: Video[]
@@ -68,49 +69,45 @@
 	{/if}
 	<div class="controls">
 		{#if sortable}
-			<button
-				class:active={$videoListSorting == VideoListSorting.NewestFirst}
-				onclick={() => {
-					videoListSorting.set(VideoListSorting.NewestFirst)
-				}}
-			>
-				<Icon type={IconType.NewestFirst} />
-				Newest
-			</button>
-			<button
-				class:active={$videoListSorting == VideoListSorting.OldestFirst}
-				onclick={() => {
-					videoListSorting.set(VideoListSorting.OldestFirst)
-				}}
-			>
-				<Icon type={IconType.OldestFirst} />
-				Oldest
-			</button>
+			<ListButtons
+				value={$videoListSorting}
+				onChange={(option) => videoListSorting.set(option)}
+				options={[
+					{
+						label: 'Newest',
+						icon: IconType.NewestFirst,
+						option: VideoListSorting.NewestFirst,
+					},
+					{
+						label: 'Oldest',
+						icon: IconType.OldestFirst,
+						option: VideoListSorting.OldestFirst,
+					},
+				]}
+			/>
 		{/if}
 		{#if !mode && sortable}
 			<div class="divider mobile-hidden"></div>
 		{/if}
 		{#if !mode}
-			<button
-				class="mobile-hidden"
-				class:active={$videoListMode == VideoListMode.List}
-				onclick={() => {
-					videoListMode.set(VideoListMode.List)
-				}}
-			>
-				<Icon type={IconType.List} />
-				List
-			</button>
-			<button
-				class="mobile-hidden"
-				class:active={$videoListMode == VideoListMode.Grid}
-				onclick={() => {
-					videoListMode.set(VideoListMode.Grid)
-				}}
-			>
-				<Icon type={IconType.Grid} />
-				Grid
-			</button>
+			<div class="mobile-hidden">
+				<ListButtons
+					value={$videoListMode}
+					onChange={(option) => videoListMode.set(option)}
+					options={[
+						{
+							label: 'List',
+							icon: IconType.List,
+							option: VideoListMode.List,
+						},
+						{
+							label: 'Grid',
+							icon: IconType.Grid,
+							option: VideoListMode.Grid,
+						},
+					]}
+				/>
+			</div>
 		{/if}
 	</div>
 </Header>
@@ -191,24 +188,6 @@
 		display: flex;
 		align-items: center;
 		margin-left: auto;
-	}
-
-	.controls button {
-		background: none;
-		border: none;
-		color: var(--color-text-muted);
-		cursor: pointer;
-		font-family: inherit;
-		font-size: 14px;
-		line-height: 20px;
-	}
-
-	.controls button:hover {
-		color: var(--color-red-active);
-	}
-
-	.controls button.active {
-		color: var(--color-text);
 	}
 
 	.controls .divider {

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -5,7 +5,7 @@
 	import Header from '$lib/components/Header.svelte'
 	import Pagination from '$lib/components/Pagination.svelte'
 	import Thumbnail from '$lib/components/Thumbnail.svelte'
-	import { videoListMode, videoListSorting } from '$lib/store.js'
+	import { videoListMode, videoListSorting } from '$lib/store'
 	import Icon, { IconType } from './Icon.svelte'
 
 	interface Props {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,56 +1,29 @@
-import { writable } from 'svelte/store'
-
+import { persisted } from 'svelte-persisted-store'
 import { VideoSource } from '$lib/data'
 import { Theme, VideoListMode } from '$lib/types'
 import { VideoListSorting } from './types'
 
-// Create a store for browsers
-const createBrowserStore = <T extends string>(key: string, defaultValue: T) => {
-	const store = writable((localStorage.getItem(key) as T) || defaultValue)
-
-	// Store the token in LocalStorage whenever it´s updated
-	store.subscribe((val) => {
-		if (!localStorage) return
-		if (!val) return localStorage.removeItem(key)
-		localStorage.setItem(key, val)
-	})
-
-	return store
-}
-
-// Create a store for Node (only used when building the site)
-const createNodeStore = <T extends any>(defaultValue: T) => writable(defaultValue)
-
 // The preferred video source
-export const preferredSource =
-	typeof localStorage === 'undefined'
-		? createNodeStore(VideoSource.InternetArchive)
-		: createBrowserStore('preferredSource', VideoSource.InternetArchive)
+export const preferredSource = persisted<VideoSource>(
+	'preferredSource',
+	VideoSource.InternetArchive
+)
 
 // Browser theme
 let defaultTheme = Theme.Light
 if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
 	defaultTheme = Theme.Dark
 }
-export const theme =
-	typeof localStorage === 'undefined'
-		? createNodeStore(defaultTheme)
-		: createBrowserStore<Theme>('theme', defaultTheme)
+export const theme = persisted<Theme>('theme', defaultTheme)
 
 // Whether to show the video in W~I~D~E mode
-export const wideVideo =
-	typeof localStorage === 'undefined'
-		? createNodeStore(false)
-		: createBrowserStore('wideVideo', false)
+export const wideVideo = persisted('wideVideo', false)
 
 // How to show the video list
-export const videoListMode =
-	typeof localStorage === 'undefined'
-		? createNodeStore(VideoListMode.List)
-		: createBrowserStore<VideoListMode>('videoListMode', VideoListMode.List)
+export const videoListMode = persisted<VideoListMode>('videoListMode', VideoListMode.List)
 
 // How to sort the video list
-export const videoListSorting =
-	typeof localStorage === 'undefined'
-		? createNodeStore(VideoListSorting.NewestFirst)
-		: createBrowserStore<VideoListSorting>('videoSorting', VideoListSorting.NewestFirst)
+export const videoListSorting = persisted<VideoListSorting>(
+	'videoSorting',
+	VideoListSorting.NewestFirst
+)

--- a/src/routes/videos/shows/+page.svelte
+++ b/src/routes/videos/shows/+page.svelte
@@ -33,12 +33,12 @@
 				options={[
 					{
 						label: 'Alphabetical',
-						icon: IconType.NewestFirst,
+						icon: IconType.LeastFirst,
 						option: ShowSorting.alphabetical,
 					},
 					{
 						label: 'Most Videos',
-						icon: IconType.OldestFirst,
+						icon: IconType.MostFirst,
 						option: ShowSorting.mostVideos,
 					},
 				]}

--- a/src/routes/videos/shows/+page.svelte
+++ b/src/routes/videos/shows/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { base } from '$app/paths'
 	import type { PageData } from './$types'
-	import Button from '$lib/components/Button.svelte'
-	import Icon, { IconType } from '$lib/components/Icon.svelte'
+	import { IconType } from '$lib/components/Icon.svelte'
 	import VideosHeader, { VideosPage } from '$lib/components/VideosHeader.svelte'
 	import { ShowSorting } from '$lib/types'
+	import Header from '$lib/components/Header.svelte'
+	import ListButtons from '$lib/components/ListButtons.svelte'
 
 	interface Props {
 		data: PageData
@@ -23,16 +24,27 @@
 </script>
 
 <VideosHeader current={VideosPage.Shows} />
-
 <section class="container shows">
-	<h1 class="sr-only">Shows</h1>
-
-	<form>
-		<select id="sorting" bind:value={sorting}>
-			<option value={ShowSorting.alphabetical}>Alphabetical</option>
-			<option value={ShowSorting.mostVideos}>Most Videos</option>
-		</select>
-	</form>
+	<Header title="Shows">
+		<div class="controls">
+			<ListButtons
+				value={sorting}
+				onChange={(option) => (sorting = option)}
+				options={[
+					{
+						label: 'Alphabetical',
+						icon: IconType.NewestFirst,
+						option: ShowSorting.alphabetical,
+					},
+					{
+						label: 'Most Videos',
+						icon: IconType.OldestFirst,
+						option: ShowSorting.mostVideos,
+					},
+				]}
+			/>
+		</div>
+	</Header>
 	<ul>
 		{#each sortedShows as show}
 			<li>
@@ -63,24 +75,22 @@
 </svelte:head>
 
 <style>
-	form {
-		margin-bottom: var(--spacing);
-	}
-
 	h2 {
 		font-size: 18px;
 		line-height: 20px;
 		margin: 0.5em 0 0.3em;
 	}
 
-	select {
-		width: 150px;
+	.controls {
+		display: flex;
+		align-items: center;
+		margin-left: auto;
 	}
 
 	ul {
 		list-style: none;
 		margin: 0;
-		padding: 0;
+		padding: var(--spacing) 0;
 	}
 
 	ul a {


### PR DESCRIPTION
This is a small effort to unify the UI by adding the `Header` bar with button controls to the Shows page.

![image](https://github.com/user-attachments/assets/1378b253-29c8-4749-934c-8961cc68618d)
![image](https://github.com/user-attachments/assets/fc3c080f-47a7-4b98-866a-e88145b7bb0e)

I was playing around with new icon designs but didn't like anything I came up with so I settled on a generic set of sort icons. The labels do the real work here, just like with the oldest/newest buttons.

I tried to avoid a massive restructure of the way the existing components are used, because the video sorting controls were in `VideoList` and I wanted them to be a bit more re-usable with the least friction.

I created a new component, `ListControls` which is used for each pair of buttons. This lets us share the styling and button/icon markup elsewhere. The way it's implemented is a little more data-driven than I'd like, but it is type safe and good enough for now.

Additionally, prompted by the risk of reading booleans as strings, the localstorage-based stores have been replaced with [a very light package](https://github.com/joshnuss/svelte-persisted-store) that handles any data types that can be json-ified and keeps multiple tabs in sync. This eliminates almost all of the boilerplate and utility functions we had in `store.ts`. The old values in localstorage from before this change will fail to parse but the default value will load instead, and when a change is made it will "migrate" the value to a parse-able quoted string.