### PR TITLE
Fix duration and hover link being incorrectly placed

### DIFF
--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -116,9 +116,11 @@
 	{#each paginatedVideos as video (video.id)}
 		<li>
 			<a href="{rootUri || `${base}/videos/${video.show}`}/{video.id}">
-				<div class="thumbnail">
-					<Thumbnail src={video.thumbnail || '/assets/default.jpg'} alt="" />
-					<span class="duration">{video.duration}</span>
+				<div class="thumbnail-wrapper">
+					<div class="thumbnail">
+						<Thumbnail src={video.thumbnail || '/assets/default.jpg'} alt="" />
+						<span class="duration">{video.duration}</span>
+					</div>
 				</div>
 				<div class="metadata">
 					<h3>{video.title}</h3>
@@ -290,7 +292,7 @@
 			display: block;
 		}
 
-		.thumbnail {
+		.thumbnail-wrapper {
 			flex: 0 0 220px;
 			margin-right: var(--spacing);
 		}
@@ -307,7 +309,7 @@
 			grid-template-columns: repeat(4, 1fr);
 		}
 
-		.thumbnail {
+		.thumbnail-wrapper {
 			flex: 0 0 260px;
 		}
 	}


### PR DESCRIPTION
There is an issue where if the description of the video is long it will cause the duration and play icon to be wrongly placed:

<img width="481" alt="Screenshot 2025-05-25 at 12 06 27" src="https://github.com/user-attachments/assets/47278128-bed7-4d91-80eb-45e23262258a" />

This is now fixed:

<img width="468" alt="Screenshot 2025-05-25 at 12 13 05" src="https://github.com/user-attachments/assets/ef3eb7ef-1fe7-4f6a-acdf-465b4737c1e8" />
