### PR TITLE
Fix incorrectly sorted thumbnails in video list

### DIFF
--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -8,6 +8,7 @@
 	import { videoListMode, videoListSorting } from '$lib/store'
 	import ListButtons from './ListButtons.svelte'
 	import { IconType } from './Icon.svelte'
+	import { onMount } from 'svelte'
 
 	interface Props {
 		videos: Video[]
@@ -61,6 +62,12 @@
 		const itemIndexStart = (currentPage - 1) * perPage
 		return sortedVideos.slice(itemIndexStart, itemIndexStart + perPage)
 	})
+
+	let hideThumbnails = $state(true)
+
+	onMount(()=>{
+		hideThumbnails = false
+	})
 </script>
 
 <Header {title}>
@@ -111,15 +118,13 @@
 		{/if}
 	</div>
 </Header>
-
 <ul class={mode ?? $videoListMode}>
 	{#each paginatedVideos as video (video.id)}
 		<li>
 			<a href="{rootUri || `${base}/videos/${video.show}`}/{video.id}">
 				<div class="thumbnail-wrapper">
 					<div class="thumbnail">
-						<Thumbnail src={video.thumbnail || '/assets/default.jpg'} alt="" />
-						<span class="duration">{video.duration}</span>
+						<Thumbnail src={hideThumbnails || !video.thumbnail ? '/assets/default.jpg' : video.thumbnail} alt="" />
 					</div>
 				</div>
 				<div class="metadata">

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -125,6 +125,7 @@
 				<div class="thumbnail-wrapper">
 					<div class="thumbnail">
 						<Thumbnail src={hideThumbnails || !video.thumbnail ? '/assets/default.jpg' : video.thumbnail} alt="" />
+						<span class="duration">{video.duration}</span>
 					</div>
 				</div>
 				<div class="metadata">

--- a/src/lib/components/VideoList.svelte
+++ b/src/lib/components/VideoList.svelte
@@ -63,7 +63,7 @@
 		return sortedVideos.slice(itemIndexStart, itemIndexStart + perPage)
 	})
 
-	let hideThumbnails = $state(true)
+	let hideThumbnails = $state(sortable)
 
 	onMount(()=>{
 		hideThumbnails = false


### PR DESCRIPTION
Fixes #87 

**The problem:** The server (or pre-render) can only render the page with the default video sorting (newest first). That's okay, because when it reaches the browser the user's preferred sorting is grabbed from localstorage and the list is re-sorted. The issue with that is Svelte's hydration doesn't like when certain things change, and that includes [attributes](https://svelte.dev/docs/svelte/runtime-warnings#Client-warnings-hydration_attribute_changed). When it detects a changed attribute, it falls back to the server value. So everything else in the list gets re-arranged to the client's sorting, except the image `src` attributes.

**A solution:** Render a fallback image on the server, and revert it `onMount`. We _could_ hide the entire video list behind a `<LoadingIndicator />`, but the less page jumpy-ness on load the better, and it's only the thumbnails that are the issue.

Let me know if you have any other ideas.